### PR TITLE
Add basic armor items and equipment updates

### DIFF
--- a/src/aquariumMap.js
+++ b/src/aquariumMap.js
@@ -7,7 +7,7 @@ export class AquariumMapManager extends MapManager {
         super(seed);
         this.name = 'aquarium';
         // wider passages help observe pathfinding for mercenaries and monsters
-        this.corridorWidth = 8;
+        this.corridorWidth = 12;
         // regenerate with the new corridor width
         this.map = this._generateMaze();
     }

--- a/src/data/items.js
+++ b/src/data/items.js
@@ -64,6 +64,42 @@ export const ITEMS = {
         toughness: 4,
     },
 
+    iron_helmet: {
+        name: '철 투구',
+        type: 'armor',
+        tags: ['armor', 'helmet'],
+        imageKey: 'iron-helmet',
+        stats: { maxHp: 3 },
+        tier: 'normal',
+        durability: 80,
+        weight: 4,
+        toughness: 5,
+    },
+
+    iron_gauntlets: {
+        name: '철 장갑',
+        type: 'armor',
+        tags: ['armor', 'gloves'],
+        imageKey: 'iron-gauntlets',
+        stats: { maxHp: 2 },
+        tier: 'normal',
+        durability: 80,
+        weight: 3,
+        toughness: 4,
+    },
+
+    iron_boots: {
+        name: '철 부츠',
+        type: 'armor',
+        tags: ['armor', 'boots'],
+        imageKey: 'iron-boots',
+        stats: { maxHp: 2 },
+        tier: 'normal',
+        durability: 80,
+        weight: 3,
+        toughness: 4,
+    },
+
     shield_basic: {
         name: '기본 방패',
         type: 'shield',

--- a/src/data/tables.js
+++ b/src/data/tables.js
@@ -27,6 +27,11 @@ export const LOOT_DROP_TABLE = [
     { id: 'violin_bow', weight: 5 },
     { id: 'estoc', weight: 5 },
     { id: 'fox_charm', weight: 10 },
+    { id: 'shield_basic', weight: 5 },
+    { id: 'leather_armor', weight: 5 },
+    { id: 'iron_helmet', weight: 5 },
+    { id: 'iron_gauntlets', weight: 5 },
+    { id: 'iron_boots', weight: 5 },
 ];
 
 // 확장성을 위해 몬스터 타입을 매개변수로 받아 드랍 테이블을 반환하는 함수

--- a/src/factory.js
+++ b/src/factory.js
@@ -143,6 +143,18 @@ export class CharacterFactory {
                     }
                 }
 
+                // 기본 방어구 장착
+                const mHelmet = this.itemFactory.create('iron_helmet', 0, 0, tileSize);
+                const mGloves = this.itemFactory.create('iron_gauntlets', 0, 0, tileSize);
+                const mBoots = this.itemFactory.create('iron_boots', 0, 0, tileSize);
+                const mArmor = this.itemFactory.create('leather_armor', 0, 0, tileSize);
+                if (mHelmet) merc.equipment.helmet = mHelmet;
+                if (mGloves) merc.equipment.gloves = mGloves;
+                if (mBoots) merc.equipment.boots = mBoots;
+                if (mArmor) merc.equipment.armor = mArmor;
+                if (merc.stats) merc.stats.updateEquipmentStats();
+                if (typeof merc.updateAI === 'function') merc.updateAI();
+
                 return merc;
             case 'monster':
                 return new Monster(finalConfig);

--- a/src/game.js
+++ b/src/game.js
@@ -67,6 +67,9 @@ export class Game {
         this.loader.loadImage('arrow', 'assets/images/arrow.png');
         this.loader.loadImage('leather_armor', 'assets/images/leatherarmor.png');
         this.loader.loadImage('plate-armor', 'assets/images/plate-armor.png');
+        this.loader.loadImage('iron-helmet', 'assets/images/iron-helmet.png');
+        this.loader.loadImage('iron-gauntlets', 'assets/images/iron-gauntlets.png');
+        this.loader.loadImage('iron-boots', 'assets/images/iron-boots.png');
         this.loader.loadImage('violin-bow', 'assets/images/violin-bow.png');
         this.loader.loadImage('skeleton', 'assets/images/skeleton.png');
         this.loader.loadImage('pet-fox', 'assets/images/pet-fox.png');
@@ -285,6 +288,16 @@ export class Game {
         });
         player.ai = null; // disable any automatic skills for the player
         player.equipmentRenderManager = this.equipmentRenderManager;
+
+        // 초기 장비 세팅
+        const pHelmet = this.itemFactory.create('iron_helmet', 0, 0, this.mapManager.tileSize);
+        const pGloves = this.itemFactory.create('iron_gauntlets', 0, 0, this.mapManager.tileSize);
+        const pBoots = this.itemFactory.create('iron_boots', 0, 0, this.mapManager.tileSize);
+        const pArmor = this.itemFactory.create('leather_armor', 0, 0, this.mapManager.tileSize);
+        if (pHelmet) this.equipmentManager.equip(player, pHelmet, null);
+        if (pGloves) this.equipmentManager.equip(player, pGloves, null);
+        if (pBoots) this.equipmentManager.equip(player, pBoots, null);
+        if (pArmor) this.equipmentManager.equip(player, pArmor, null);
         this.gameState = {
             player,
             inventory: [],
@@ -366,7 +379,7 @@ export class Game {
                 // 몬스터 초기 장비 및 소지품 설정
                 monster.consumables = [];
                 monster.consumableCapacity = 4;
-                const itemCount = Math.floor(Math.random() * 3) + 1;
+                const itemCount = Math.floor(Math.random() * 3) + 2; // 장비 다양화를 위해 최소 2개
                 for (let j = 0; j < itemCount; j++) {
                     const id = rollOnTable(getMonsterLootTable());
                     const item = this.itemFactory.create(

--- a/src/managers/equipmentManager.js
+++ b/src/managers/equipmentManager.js
@@ -85,6 +85,9 @@ export class EquipmentManager {
 
         // 2. 기존 로직 (하위 호환용)
         if ((item.tags && item.tags.includes('weapon')) || item.type === 'weapon') return 'main_hand';
+        if ((item.tags && item.tags.includes('helmet'))) return 'helmet';
+        if ((item.tags && item.tags.includes('gloves'))) return 'gloves';
+        if ((item.tags && item.tags.includes('boots'))) return 'boots';
         if ((item.tags && item.tags.includes('armor')) || item.type === 'armor') return 'armor';
         return null;
     }


### PR DESCRIPTION
## Summary
- widen aquarium corridors for testing
- introduce iron helmet, gauntlets, and boots
- extend loot tables with new armor
- give mercenaries and players starter armor
- load new armor images and spawn more varied monster gear
- support new armor slots in EquipmentManager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685861faab2483278e0f7861845cb556