### PR TITLE
Adjust enemy vision range

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -71,6 +71,12 @@ export class CharacterFactory {
             properties,
         };
 
+        // Reduce vision range for all monsters and mercenaries
+        if (type === 'monster' || type === 'mercenary') {
+            const baseVision = finalConfig.stats.visionRange ?? 192 * 4;
+            finalConfig.stats.visionRange = Math.floor(baseVision / 3);
+        }
+
         // 4. 타입에 맞는 캐릭터 생성 및 반환
         switch (type) {
             case 'player':


### PR DESCRIPTION
## Summary
- cut monster and mercenary vision distance to one third
- keep all tests green

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68586b36b8c083279b30bc8f035be24e