### PR TITLE
Tighten Aquarium corridors for maze layout

### DIFF
--- a/src/aquariumMap.js
+++ b/src/aquariumMap.js
@@ -6,19 +6,18 @@ export class AquariumMapManager extends MapManager {
     constructor(seed) {
         super(seed);
         this.name = 'aquarium';
-        // wider passages help observe pathfinding for mercenaries and monsters
-        this.corridorWidth = 12;
+        // slightly narrower corridors for a tighter maze feel
+        this.corridorWidth = 6;
         // regenerate with the new corridor width
         this.map = this._generateMaze();
     }
 
     _generateMaze() {
-        // use the base maze generation but with a larger corridor width
+        // use the base maze generation with the adjusted corridor width
         return super._generateMaze();
     }
 
-    // Aquarium floors focus on wide corridors for pathfinding tests, so skip
-    // placing rooms to create a pure maze layout.
+    // Aquarium floors skip room generation to emphasize maze corridors.
     _generateRooms(map) {
         // no-op to keep corridors unobstructed
     }

--- a/tests/aquarium.test.js
+++ b/tests/aquarium.test.js
@@ -12,9 +12,9 @@ import { describe, test, assert } from './helpers.js';
 const assets = { monster:{} };
 
 describe('Aquarium', () => {
-    test('Aquarium map uses a wide maze layout', () => {
+    test('Aquarium map uses a maze layout', () => {
         const m = new AquariumMapManager(1);
-        assert.ok(m.corridorWidth >= 8, 'corridor width should be wide');
+        assert.ok(m.corridorWidth <= 8, 'corridor width should be maze-like');
         const wallCount = m.countTiles(m.tileTypes.WALL);
         assert.ok(wallCount > 0 && wallCount < m.width * m.height, 'maze should contain walls and floors');
     });


### PR DESCRIPTION
## Summary
- narrow Aquarium map corridors for a proper maze feel
- update comments to reflect new layout
- adjust test to expect narrower corridor width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858705b505483278ab7264e8bd96b23