### PR TITLE
Add formation-aware AI helper

### DIFF
--- a/src/utils/entityUtils.js
+++ b/src/utils/entityUtils.js
@@ -23,3 +23,23 @@ export function findEntitiesInRadius(centerX, centerY, radius, entities, exclude
     }
     return found;
 }
+
+/**
+ * 주어진 위치에서 가장 가까운 엔티티를 찾습니다.
+ * @param {{x:number,y:number}} pos - 기준 위치
+ * @param {Entity[]} entities - 검색 대상 엔티티 배열
+ * @returns {Entity|null}
+ */
+export function findNearestEntity(pos, entities) {
+    if (!entities || entities.length === 0) return null;
+    let nearest = null;
+    let minDist = Infinity;
+    for (const entity of entities) {
+        const d = Math.hypot(pos.x - entity.x, pos.y - entity.y);
+        if (d < minDist) {
+            minDist = d;
+            nearest = entity;
+        }
+    }
+    return nearest;
+}

--- a/src/utils/geometry.js
+++ b/src/utils/geometry.js
@@ -26,3 +26,28 @@ export function hasLineOfSight(x0, y0, x1, y1, mapManager) {
     }
     return true;
 }
+
+/**
+ * 엔티티 목록의 평균 위치를 계산합니다.
+ * @param {Array<{x:number,y:number}>} entityList
+ * @returns {{x:number,y:number}|null}
+ */
+export function getAveragePosition(entityList) {
+    if (!entityList || entityList.length === 0) return null;
+    const totalX = entityList.reduce((sum, e) => sum + e.x, 0);
+    const totalY = entityList.reduce((sum, e) => sum + e.y, 0);
+    return { x: totalX / entityList.length, y: totalY / entityList.length };
+}
+
+/**
+ * 두 지점 사이의 거리를 계산합니다.
+ * @param {{x:number,y:number}} a
+ * @param {{x:number,y:number}} b
+ * @returns {number}
+ */
+export function getDistance(a, b) {
+    if (!a || !b) return Infinity;
+    const dx = a.x - b.x;
+    const dy = a.y - b.y;
+    return Math.hypot(dx, dy);
+}


### PR DESCRIPTION
## Summary
- implement `getAveragePosition` and `getDistance` helpers
- implement `findNearestEntity` utility
- add experimental `decideNextAction` in `ai.js`
- export new utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685874399ec08327b030a63fd7bcdcce