### PR TITLE
Enable skill actions in MetaAI manager

### DIFF
--- a/src/managers/metaAIManager.js
+++ b/src/managers/metaAIManager.js
@@ -5,6 +5,7 @@ export class MetaAIManager extends BaseMetaAI {
     executeAction(entity, action, context) {
         if (!action) return;
         const { player, mapManager, onPlayerAttack, onMonsterAttacked } = context;
+
         switch (action.type) {
             case 'attack':
                 if (entity.attackCooldown === 0) {
@@ -37,8 +38,9 @@ export class MetaAIManager extends BaseMetaAI {
                     }
                 }
                 break;
-            case 'idle':
             default:
+                // 나머지 행동 유형은 기본 메서드에 위임한다
+                super.executeAction(entity, action, context);
                 break;
         }
     }


### PR DESCRIPTION
## Summary
- delegate unknown action types to base `MetaAIManager`
- this allows warrior, archer, wizard and bard AIs to actually cast their skills

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858762962088327bf8ea8bb58c6296d