### PR TITLE
Add side-scroller style map

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -10,6 +10,7 @@ import { CombatCalculator } from './combat.js';
 import { TagManager } from './managers/tagManager.js';
 import { MapManager } from './map.js';
 import { AquariumMapManager } from './aquariumMap.js';
+import { SideScrollerMapManager } from './sideScrollerMap.js';
 import { AquariumManager, AquariumInspector } from './managers/aquariumManager.js';
 import * as Managers from './managers/index.js'; // managers/index.js에서 모든 매니저를 한 번에 불러옴
 import { AssetLoader } from './assetLoader.js';
@@ -104,8 +105,8 @@ export class Game {
         this.systemLogManager = new SystemLogManager(this.eventManager);
         this.tagManager = new TagManager();
         this.combatCalculator = new CombatCalculator(this.eventManager, this.tagManager);
-        // Player begins in the Aquarium map for feature testing
-        this.mapManager = new AquariumMapManager();
+        // Player begins in a side-scroller style map
+        this.mapManager = new SideScrollerMapManager();
         this.saveLoadManager = new SaveLoadManager();
         this.turnManager = new TurnManager();
         this.narrativeManager = new NarrativeManager();

--- a/src/sideScrollerMap.js
+++ b/src/sideScrollerMap.js
@@ -1,0 +1,56 @@
+import { MapManager } from './map.js';
+
+export class SideScrollerMapManager extends MapManager {
+    constructor(seed) {
+        super(seed);
+        this.name = 'sideScroller';
+        this.roomWidth = 8;
+        this.roomHeight = 6;
+        this.columns = 3;
+        this.rows = 2;
+        this.corridorWidth = 2;
+        this.map = this._generateMaze();
+    }
+
+    _generateMaze() {
+        const width = this.columns * this.roomWidth + (this.columns + 1) * this.corridorWidth;
+        const height = this.rows * this.roomHeight + (this.rows + 1) * this.corridorWidth;
+        this.width = width;
+        this.height = height;
+        const map = Array.from({ length: height }, () => Array(width).fill(this.tileTypes.WALL));
+        this.rooms = [];
+
+        for (let r = 0; r < this.rows; r++) {
+            for (let c = 0; c < this.columns; c++) {
+                const roomX = this.corridorWidth + c * (this.roomWidth + this.corridorWidth);
+                const roomY = this.corridorWidth + r * (this.roomHeight + this.corridorWidth);
+                for (let y = roomY; y < roomY + this.roomHeight; y++) {
+                    for (let x = roomX; x < roomX + this.roomWidth; x++) {
+                        map[y][x] = this.tileTypes.FLOOR;
+                    }
+                }
+                this.rooms.push({ x: roomX, y: roomY, width: this.roomWidth, height: this.roomHeight });
+
+                if (c > 0) {
+                    const corridorY = roomY + Math.floor(this.roomHeight / 2);
+                    const startX = roomX - this.corridorWidth;
+                    for (let y = corridorY; y < corridorY + this.corridorWidth; y++) {
+                        for (let x = startX; x < roomX; x++) {
+                            map[y][x] = this.tileTypes.FLOOR;
+                        }
+                    }
+                }
+                if (r > 0) {
+                    const corridorX = roomX + Math.floor(this.roomWidth / 2);
+                    const startY = roomY - this.corridorWidth;
+                    for (let x = corridorX; x < corridorX + this.corridorWidth; x++) {
+                        for (let y = startY; y < roomY; y++) {
+                            map[y][x] = this.tileTypes.FLOOR;
+                        }
+                    }
+                }
+            }
+        }
+        return map;
+    }
+}

--- a/tests/sideScrollerMap.test.js
+++ b/tests/sideScrollerMap.test.js
@@ -1,0 +1,43 @@
+import { SideScrollerMapManager } from '../src/sideScrollerMap.js';
+import { describe, test, assert } from './helpers.js';
+
+describe('SideScrollerMapManager', () => {
+  test('rooms are connected', () => {
+    const mapManager = new SideScrollerMapManager(12345);
+    const { width, height, tileTypes, map } = mapManager;
+    let start = null;
+    let floorCount = 0;
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        if (map[y][x] !== tileTypes.WALL) {
+          if (!start) start = { x, y };
+          floorCount++;
+        }
+      }
+    }
+    assert.ok(start, '맵에 시작 지점을 찾을 수 없습니다.');
+    const visited = new Set();
+    const queue = [start];
+    visited.add(`${start.x},${start.y}`);
+    let connectedCount = 0;
+    while (queue.length > 0) {
+      const current = queue.shift();
+      connectedCount++;
+      const { x, y } = current;
+      const neighbors = [
+        { x: x + 1, y },
+        { x: x - 1, y },
+        { x, y: y + 1 },
+        { x, y: y - 1 }
+      ];
+      for (const n of neighbors) {
+        const key = `${n.x},${n.y}`;
+        if (map[n.y] && map[n.y][n.x] !== tileTypes.WALL && !visited.has(key)) {
+          visited.add(key);
+          queue.push(n);
+        }
+      }
+    }
+    assert.strictEqual(connectedCount, floorCount, '맵이 고립된 공간을 포함합니다.');
+  });
+});


### PR DESCRIPTION
## Summary
- add `SideScrollerMapManager` to build a grid of rooms connected in four directions
- use the new map type in the main game setup
- test connectivity for side-scroller maps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685879556ab08327825a992ca0e98dbb