### PR TITLE
Adjust detail panel layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,30 +77,33 @@
     <div id="mercenary-detail-panel" class="modal-panel ui-frame hidden">
         <button id="close-merc-detail-btn" class="close-btn">X</button>
         <h2 id="merc-detail-name">용병 이름</h2>
-        <div class="stats-content-box">
-            <div id="merc-stats-container">
+        <div class="stats-content-box sheet-container">
+            <div class="sheet-left">
+                <div id="merc-equipment-section">
+                    <h3>장비</h3>
+                    <div id="merc-equipment" class="equipment-slots">
+                        <div class="equip-slot" data-slot="main_hand"></div>
+                        <div class="equip-slot" data-slot="off_hand"></div>
+                        <div class="equip-slot" data-slot="armor"></div>
+                        <div class="equip-slot" data-slot="helmet"></div>
+                        <div class="equip-slot" data-slot="gloves"></div>
+                        <div class="equip-slot" data-slot="boots"></div>
+                        <div class="equip-slot" data-slot="accessory1"></div>
+                        <div class="equip-slot" data-slot="accessory2"></div>
+                    </div>
+                </div>
+                <div id="merc-inventory-section">
+                    <h3>인벤토리</h3>
+                    <div id="merc-inventory"></div>
+                </div>
             </div>
-        </div>
-        <div id="merc-equipment-section">
-            <h3>장비</h3>
-            <div id="merc-equipment" class="equipment-slots">
-                <div class="equip-slot" data-slot="main_hand"></div>
-                <div class="equip-slot" data-slot="off_hand"></div>
-                <div class="equip-slot" data-slot="armor"></div>
-                <div class="equip-slot" data-slot="helmet"></div>
-                <div class="equip-slot" data-slot="gloves"></div>
-                <div class="equip-slot" data-slot="boots"></div>
-                <div class="equip-slot" data-slot="accessory1"></div>
-                <div class="equip-slot" data-slot="accessory2"></div>
+            <div class="sheet-right">
+                <div id="merc-stats-container"></div>
+                <div id="merc-skills-section">
+                    <h3>스킬</h3>
+                    <div id="merc-skills" class="skill-list"></div>
+                </div>
             </div>
-        </div>
-        <div id="merc-inventory-section">
-            <h3>인벤토리</h3>
-            <div id="merc-inventory"></div>
-        </div>
-        <div id="merc-skills-section">
-            <h3>스킬</h3>
-            <div id="merc-skills" class="skill-list"></div>
         </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -63,6 +63,16 @@ body, html {
     display: none;
 }
 
+/* Unit detail panels */
+#character-sheet-panel,
+#mercenary-detail-panel {
+    top: 40%;
+    width: 640px;
+    max-width: 90vw;
+    max-height: 90vh;
+    overflow-y: auto;
+}
+
 /* 툴팁 (최상위) */
 .tooltip {
     position: fixed;


### PR DESCRIPTION
## Summary
- tweak mercenary detail markup to mimic character sheet square layout
- set shared style for unit detail panels and move them upward

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858985102f48327ae9efa11e611e3e7