### PR TITLE
Fix TensorFlow.js import for browser

### DIFF
--- a/src/managers/pathfindingManager.js
+++ b/src/managers/pathfindingManager.js
@@ -1,5 +1,5 @@
 // src/pathfindingManager.js
-import * as tf from '@tensorflow/tfjs';
+import { loadTf } from '../utils/tf-loader.js';
 
 export class PathfindingManager {
     constructor(mapManager) {
@@ -124,6 +124,7 @@ export class PathfindingManager {
 
     async findPathTensor(startX, startY, endX, endY) {
         try {
+            const tf = await loadTf();
             if (!this.model) {
                 this.model = await tf.loadLayersModel('./assets/pathfinding-model.json');
             }

--- a/src/utils/tf-loader.js
+++ b/src/utils/tf-loader.js
@@ -1,0 +1,23 @@
+export async function loadTf() {
+    if (loadTf.tfPromise) return loadTf.tfPromise;
+
+    if (typeof window !== 'undefined') {
+        if (window.tf) {
+            loadTf.tfPromise = Promise.resolve(window.tf);
+        } else {
+            loadTf.tfPromise = import('https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.22.0/dist/tf.es2017.js')
+                .then(mod => {
+                    window.tf = mod;
+                    return mod;
+                })
+                .catch(err => {
+                    console.warn('[tf-loader] Failed to load TensorFlow.js', err);
+                    throw err;
+                });
+        }
+    } else {
+        loadTf.tfPromise = import('@tensorflow/tfjs');
+    }
+
+    return loadTf.tfPromise;
+}


### PR DESCRIPTION
## Summary
- add tf-loader utility
- dynamically load TensorFlow.js in MbtiEngine and PathfindingManager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858a5bf1a58832791c4fc705200b1fe