### PR TITLE
Add TensorFlow-powered combat item behaviors

### DIFF
--- a/src/managers/ai/CombatDecisionEngine.js
+++ b/src/managers/ai/CombatDecisionEngine.js
@@ -1,0 +1,37 @@
+import { loadTf } from '../../utils/tf-loader.js';
+
+export class CombatDecisionEngine {
+    constructor() {
+        this.tf = null;
+        this.model = null;
+        loadTf().then(tf => { this.tf = tf; this._init(); }).catch(() => {});
+    }
+
+    _init() {
+        if (this.tf && !this.model) {
+            const tf = this.tf;
+            this.model = tf.sequential();
+            this.model.add(tf.layers.dense({ units: 1, inputShape: [4], useBias: false }));
+            // 단순 가중치 모델 (시연용)
+            this.model.setWeights([tf.tensor2d([[1],[1],[0.5],[0.5]])]);
+        }
+    }
+
+    shouldPickup(slotEmpty, distance, weight, hpRatio) {
+        if (!this.model) return slotEmpty && distance <= 64;
+        const tf = this.tf;
+        const t = tf.tensor2d([[slotEmpty ? 1 : 0, distance / 100, weight / 10, hpRatio]]);
+        const out = this.model.predict(t).dataSync()[0];
+        tf.dispose(t);
+        return out > 0.5;
+    }
+
+    shouldThrowWeapon(hpRatio, distance, weight) {
+        if (!this.model) return hpRatio < 0.3 && distance <= 96;
+        const tf = this.tf;
+        const t = tf.tensor2d([[1 - hpRatio, distance / 100, weight / 10, 0]]);
+        const out = this.model.predict(t).dataSync()[0];
+        tf.dispose(t);
+        return out > 0.5;
+    }
+}

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -26,6 +26,7 @@ import { SynergyManager } from '../micro/SynergyManager.js';
 import { SpeechBubbleManager } from './speechBubbleManager.js';
 import { AuraManager } from './AuraManager.js';
 import { PossessionAIManager } from './possessionAIManager.js';
+import { CombatDecisionEngine } from './ai/CombatDecisionEngine.js';
 // 파일 기반 로거는 Node 환경 전용이라 기본 묶음에서 제외한다
 // import { FileLogManager } from './fileLogManager.js';
 // ... (나중에 다른 매니저가 생기면 여기에 추가)
@@ -56,4 +57,5 @@ export {
     AuraManager,
     SynergyManager,
     SpeechBubbleManager,
+    CombatDecisionEngine,
 };

--- a/src/managers/item-ai-manager.js
+++ b/src/managers/item-ai-manager.js
@@ -1,9 +1,12 @@
+import { CombatDecisionEngine } from './ai/CombatDecisionEngine.js';
+
 export class ItemAIManager {
     constructor(eventManager = null, projectileManager = null, vfxManager = null, effectManager = null) {
         this.eventManager = eventManager;
         this.projectileManager = projectileManager;
         this.vfxManager = vfxManager;
         this.effectManager = effectManager;
+        this.decisionEngine = new CombatDecisionEngine();
     }
 
     setEffectManager(effectManager) {
@@ -32,8 +35,11 @@ export class ItemAIManager {
 
             this._handleHealingItems(ent, entities);
             this._handleArtifacts(ent);
+            this._pickupEquipment(ent, context);
+            this._pickupConsumables(ent, context);
 
             if (nearbyEnemies.length > 0) {
+                this._maybeThrowWeapon(ent, nearbyEnemies[0], context);
                 this._handleBuffItems(ent, entities);
             }
         }
@@ -145,6 +151,68 @@ export class ItemAIManager {
         if (!self.effects.some(e => e.id === item.effectId)) {
             this._useItem(self, item, self);
         }
+    }
+
+    _pickupEquipment(entity, context) {
+        const { itemManager, equipmentManager } = context;
+        if (!itemManager || !equipmentManager) return;
+        const slots = ['main_hand','armor','helmet','gloves','boots','off_hand'];
+        for (const slot of slots) {
+            if (entity.equipment?.[slot]) continue;
+            const item = itemManager.items.find(it =>
+                this._matchesSlot(it, slot) &&
+                Math.hypot(it.x - entity.x, it.y - entity.y) <= entity.tileSize * 1.5);
+            if (item) {
+                const ok = this.decisionEngine.shouldPickup(true,
+                    Math.hypot(item.x - entity.x, item.y - entity.y),
+                    item.weight || 1,
+                    entity.hp / entity.maxHp);
+                if (ok) {
+                    itemManager.removeItem(item);
+                    equipmentManager.equip(entity, item, null);
+                    break;
+                }
+            }
+        }
+    }
+
+    _pickupConsumables(entity, context) {
+        const { itemManager } = context;
+        const capacity = entity.consumableCapacity || 0;
+        if (!itemManager || capacity <= (entity.consumables?.length || 0)) return;
+        const item = itemManager.items.find(it => it.tags?.includes('consumable') &&
+            Math.hypot(it.x - entity.x, it.y - entity.y) <= entity.tileSize * 1.5);
+        if (item) {
+            const ok = this.decisionEngine.shouldPickup(true,
+                Math.hypot(item.x - entity.x, item.y - entity.y),
+                item.weight || 1,
+                entity.hp / entity.maxHp);
+            if (ok) {
+                itemManager.removeItem(item);
+                entity.addConsumable?.(item);
+                this._useItem(entity, item, entity);
+            }
+        }
+    }
+
+    _maybeThrowWeapon(entity, target, context) {
+        const { projectileManager, itemManager, equipmentManager } = context;
+        const weapon = entity.equipment?.weapon;
+        if (!weapon || !projectileManager || !itemManager || !equipmentManager) return;
+        const dist = Math.hypot(target.x - entity.x, target.y - entity.y);
+        const hpRatio = entity.hp / entity.maxHp;
+        const ok = this.decisionEngine.shouldThrowWeapon(hpRatio, dist, weapon.weight || 1);
+        if (ok) {
+            equipmentManager.unequip(entity, 'weapon', null);
+            projectileManager.throwItem(entity, target, weapon, (weapon.weight || 1) + (entity.damageBonus || 0), itemManager);
+        }
+    }
+
+    _matchesSlot(item, slot) {
+        if (slot === 'main_hand') return item.tags?.includes('weapon') || item.type === 'weapon';
+        if (slot === 'off_hand') return item.tags?.includes('shield') || item.slot === 'off_hand';
+        if (slot === 'armor') return item.tags?.includes('armor') || item.type === 'armor';
+        return item.tags?.includes(slot);
     }
 
     _useItem(user, item, target) {

--- a/src/managers/projectileManager.js
+++ b/src/managers/projectileManager.js
@@ -42,13 +42,13 @@ export class ProjectileManager {
         }
     }
 
-    throwItem(caster, target, item) {
+    throwItem(caster, target, item, damage = 0, itemManager = null) {
         const config = {
             x: caster.x + caster.width / 2,
             y: caster.y + caster.height / 2,
             target,
             caster,
-            damage: 0,
+            damage,
             knockbackStrength: 0,
             image: item.image,
             width: item.width,
@@ -58,6 +58,8 @@ export class ProjectileManager {
             vfxManager: this.vfxManager,
         };
         const projectile = new Projectile(config);
+        projectile.droppedItem = item;
+        projectile.itemManager = itemManager;
         this.projectiles.push(projectile);
     }
 
@@ -101,6 +103,12 @@ export class ProjectileManager {
                             this.eventManager.publish('entity_attack', { attacker: proj.caster, defender: aoeTarget, damage: proj.damage * 0.5 });
                         }
                     }
+                }
+
+                if (proj.droppedItem && proj.itemManager) {
+                    proj.droppedItem.x = result.target.x;
+                    proj.droppedItem.y = result.target.y;
+                    proj.itemManager.addItem(proj.droppedItem);
                 }
 
                 this.projectiles.splice(index, 1);

--- a/tests/itemAiManager.test.js
+++ b/tests/itemAiManager.test.js
@@ -24,4 +24,20 @@ describe('ItemAI', () => {
     assert.ok(merc.hp > merc.maxHp * 0.4, 'hp should increase');
     assert.strictEqual(merc.consumables.length, 0, 'potion consumed');
   });
+
+  test('picks up and equips nearby weapon', () => {
+    const factory = new CharacterFactory(assets);
+    const itemFactory = new ItemFactory(assets);
+    const eventManager = new EventManager();
+    const projectileManager = new ProjectileManager(eventManager, assets);
+    const itemAI = new ItemAIManager(eventManager, projectileManager, null, { addEffect(){} });
+    const merc = factory.create('mercenary', { x:0, y:0, tileSize:1, groupId:'g', jobId:'warrior' });
+    merc.equipment.weapon = null;
+    const sword = itemFactory.create('short_sword', 0,0,1);
+    const itemManager = { items:[sword], removeItem(i){ this.items=this.items.filter(it=>it!==i); } };
+    const context = { player:merc, mercenaryManager:{ mercenaries:[merc] }, monsterManager:{ monsters:[] }, itemManager, equipmentManager:{ equip(e,i){ e.equipment.weapon=i; } } };
+    itemAI.update(context);
+    assert.strictEqual(merc.equipment.weapon, sword, 'weapon equipped');
+    assert.strictEqual(itemManager.items.length, 0, 'item removed from ground');
+  });
 });


### PR DESCRIPTION
## Summary
- create `CombatDecisionEngine` using TensorFlow.js
- extend `ItemAIManager` to auto pick up equipment/consumables and throw weapons
- update `ProjectileManager` to support item drops after throwing
- export new engine and add tests for pickup logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858aa18507c83279d55fd89888757de