### PR TITLE
Add TensorFlow model loaders and autoencoder test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@tensorflow-models/coco-ssd": "^2.2.3",
+    "@tensorflow-models/knn-classifier": "^1.2.6",
     "@tensorflow/tfjs": "^4.22.0"
   }
 }

--- a/src/managers/ai/MbtiEngine.js
+++ b/src/managers/ai/MbtiEngine.js
@@ -1,4 +1,4 @@
-import { loadTf } from '../../utils/tf-loader.js';
+import { loadTf, loadCocoSsd, loadKnnClassifier } from '../../utils/tf-loader.js';
 
 export class MbtiEngine {
     constructor(eventManager, options = {}) {
@@ -11,8 +11,16 @@ export class MbtiEngine {
         this.model = null;
         this.modelLoaded = false;
         this.tf = null;
+        this.coco = null;
+        this.knn = null;
         loadTf().then(tf => { this.tf = tf; }).catch(err => {
             console.warn('[MbtiEngine] Failed to load TensorFlow.js:', err);
+        });
+        loadCocoSsd().then(mod => { this.coco = mod; }).catch(err => {
+            console.warn('[MbtiEngine] Failed to load coco-ssd:', err);
+        });
+        loadKnnClassifier().then(mod => { this.knn = mod; }).catch(err => {
+            console.warn('[MbtiEngine] Failed to load knn-classifier:', err);
         });
 
         if (options.model) {

--- a/src/utils/tf-loader.js
+++ b/src/utils/tf-loader.js
@@ -21,3 +21,17 @@ export async function loadTf() {
 
     return loadTf.tfPromise;
 }
+
+export async function loadCocoSsd() {
+    if (!loadCocoSsd.promise) {
+        loadCocoSsd.promise = import('@tensorflow-models/coco-ssd');
+    }
+    return loadCocoSsd.promise;
+}
+
+export async function loadKnnClassifier() {
+    if (!loadKnnClassifier.promise) {
+        loadKnnClassifier.promise = import('@tensorflow-models/knn-classifier');
+    }
+    return loadKnnClassifier.promise;
+}

--- a/tests/embargo.test.js
+++ b/tests/embargo.test.js
@@ -126,12 +126,25 @@ test('차지 어택과 포션 사용 시나리오', () => {
     assert.ok(usedPurify || player.effects.some(e => e.id === 'poison'), 'Healer may skip purify based on MBTI');
 });
 
- test('TensorFlow simple inference', () => {
+test('TensorFlow simple inference', () => {
+    const model = tf.sequential();
+    model.add(tf.layers.dense({ units: 1, inputShape: [2], useBias: false }));
+    model.setWeights([tf.tensor2d([[1],[1]])]);
+    const output = model.predict(tf.tensor2d([[2, 3]])).dataSync()[0];
+    assert.strictEqual(output, 5, 'TensorFlow model should compute sum');
+});
+
+ test('Autoencoder reconstruction', () => {
+     const input = tf.tensor2d([[0.1, 0.2, 0.3]]);
+     const encoder = tf.layers.dense({ units: 3, inputShape: [3], useBias: false });
+     const decoder = tf.layers.dense({ units: 3, useBias: false });
      const model = tf.sequential();
-     model.add(tf.layers.dense({ units: 1, inputShape: [2], useBias: false }));
-     model.setWeights([tf.tensor2d([[1],[1]])]);
-     const output = model.predict(tf.tensor2d([[2, 3]])).dataSync()[0];
-     assert.strictEqual(output, 5, 'TensorFlow model should compute sum');
+     model.add(encoder);
+     model.add(decoder);
+     encoder.setWeights([tf.eye(3)]);
+     decoder.setWeights([tf.eye(3)]);
+     const output = model.predict(input).arraySync()[0];
+     assert.ok(Math.abs(output[0] - 0.1) < 1e-6, 'Autoencoder should reconstruct');
  });
 
 


### PR DESCRIPTION
## Summary
- extend TensorFlow loader with `loadCocoSsd` and `loadKnnClassifier`
- initialize Coco SSD and KNN modules inside `MbtiEngine`
- include simple autoencoder example in `embargo.test.js`
- depend on `@tensorflow-models/coco-ssd` and `@tensorflow-models/knn-classifier`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858abd441708327aae59ed050c1b82e