### PR TITLE
Add DataRecorder utility for event logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ npm install
 await metaAIManager.mbtiEngine.loadModel('models/mbti-model/model.json');
 ```
 
+데이터 수집을 위해 Node 환경에서 실행할 경우 `DataRecorder`를 활성화할 수 있습니다.
+`EventManager` 인스턴스 후 다음과 같이 초기화하세요:
+
+```javascript
+import { DataRecorder } from './src/managers/dataRecorder.js';
+const recorder = new DataRecorder(eventManager, './logs/sim.csv', 'csv');
+```
+
+기본 포맷은 JSONL이며, 두 번째 인수로 경로와 세 번째 인수로 `csv` 혹은 `json` 형식을
+선택할 수 있습니다.
+
 
 ## 결함 주입 테스트
 MBTI AI와 힐러 AI의 오류 처리 능력을 확인하는 시나리오가 `tests/faultInjection.test.js`에 있습니다. 버퍼/디버퍼 AI가 추가되면 동일한 파일에서 함께 관리합니다.

--- a/src/managers/dataRecorder.js
+++ b/src/managers/dataRecorder.js
@@ -1,0 +1,35 @@
+import { appendFileSync, writeFileSync } from 'fs';
+
+export class DataRecorder {
+    constructor(eventManager, filePath = 'record.jsonl', format = 'json') {
+        this.filePath = filePath;
+        this.format = format;
+        try {
+            writeFileSync(this.filePath, '', { flag: 'w' });
+        } catch (e) {
+            console.error('Failed to initialize data recorder file', e);
+        }
+        const events = ['log', 'damage_calculated', 'simulation_step'];
+        events.forEach(evt => eventManager.subscribe(evt, data => this.write(evt, data)));
+    }
+
+    write(eventName, data = {}) {
+        try {
+            const line = this.format === 'csv'
+                ? this.toCSV({ event: eventName, ...data })
+                : JSON.stringify({ event: eventName, ...data });
+            appendFileSync(this.filePath, line + '\n');
+        } catch (e) {
+            console.error('Failed to record data', e);
+        }
+    }
+
+    toCSV(obj) {
+        return Object.values(obj).map(v => {
+            if (typeof v === 'object') {
+                return JSON.stringify(v);
+            }
+            return String(v).replace(/,/g, ';');
+        }).join(',');
+    }
+}

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -27,6 +27,12 @@ import { SpeechBubbleManager } from './speechBubbleManager.js';
 import { AuraManager } from './AuraManager.js';
 import { PossessionAIManager } from './possessionAIManager.js';
 import { CombatDecisionEngine } from './ai/CombatDecisionEngine.js';
+// DataRecorder is only needed in a Node.js environment so we lazy-load it
+let DataRecorder = null;
+if (typeof process !== 'undefined' && process.versions?.node) {
+    const mod = await import('./dataRecorder.js');
+    DataRecorder = mod.DataRecorder;
+}
 // 파일 기반 로거는 Node 환경 전용이라 기본 묶음에서 제외한다
 // import { FileLogManager } from './fileLogManager.js';
 // ... (나중에 다른 매니저가 생기면 여기에 추가)
@@ -58,4 +64,5 @@ export {
     SynergyManager,
     SpeechBubbleManager,
     CombatDecisionEngine,
+    DataRecorder,
 };

--- a/tests/dataRecorder.test.js
+++ b/tests/dataRecorder.test.js
@@ -1,0 +1,23 @@
+import { EventManager } from '../src/managers/eventManager.js';
+import { DataRecorder } from '../src/managers/dataRecorder.js';
+import { existsSync, readFileSync, unlinkSync } from 'fs';
+import { describe, test, assert } from './helpers.js';
+
+const DATA_PATH = './tests/tmp-data.jsonl';
+
+describe('DataRecorder', () => {
+    test('records events to file', () => {
+        if (existsSync(DATA_PATH)) unlinkSync(DATA_PATH);
+        const eventManager = new EventManager();
+        new DataRecorder(eventManager, DATA_PATH, 'json');
+        eventManager.publish('log', { message: 'hello' });
+        eventManager.publish('damage_calculated', { damage: 5 });
+        eventManager.publish('simulation_step', { step: 1 });
+        const content = readFileSync(DATA_PATH, 'utf-8').trim().split('\n');
+        assert.strictEqual(content.length, 3);
+        const first = JSON.parse(content[0]);
+        assert.strictEqual(first.event, 'log');
+        assert.strictEqual(first.message, 'hello');
+        unlinkSync(DATA_PATH);
+    });
+});


### PR DESCRIPTION
## Summary
- implement Node-based `DataRecorder` for capturing events
- load `DataRecorder` lazily from managers index in Node.js
- document recorder usage in README
- test that events are stored to a file

## Testing
- `GROUP=DataRecorder node tests/dataRecorder.test.js`
- `npm test` *(fails: Cannot find package '@tensorflow/tfjs')*

------
https://chatgpt.com/codex/tasks/task_e_6858ae00f6ac8327bd51db526f8a3cf5