### PR TITLE
Show MBTI trait source

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -951,7 +951,8 @@ export class Game {
         // AI가 성격 특성을 발동했을 때 텍스트 팝업으로 표시
         eventManager.subscribe('ai_mbti_trait_triggered', (data) => {
             if (this.vfxManager) {
-                this.vfxManager.addTextPopup(data.trait, data.entity);
+                const text = data.tfUsed ? `${data.trait}(tf)` : data.trait;
+                this.vfxManager.addTextPopup(text, data.entity);
             }
         });
 

--- a/src/managers/ai/MbtiEngine.js
+++ b/src/managers/ai/MbtiEngine.js
@@ -79,7 +79,9 @@ export class MbtiEngine {
         }
 
         const mbti = entity.properties.mbti;
-        let traitToPublish = this._predictTrait(entity, action);
+        const predictedTrait = this._predictTrait(entity, action);
+        let traitToPublish = predictedTrait;
+        let tfUsed = !!predictedTrait;
 
         // 기존 규칙 기반 판단(백업)
         if (!traitToPublish) {
@@ -121,7 +123,8 @@ export class MbtiEngine {
         if (traitToPublish) {
             this.eventManager.publish('ai_mbti_trait_triggered', {
                 entity,
-                trait: traitToPublish
+                trait: traitToPublish,
+                tfUsed
             });
             entity._mbtiCooldown = this.cooldown;
         }

--- a/tests/mbtiEngine.test.js
+++ b/tests/mbtiEngine.test.js
@@ -14,6 +14,7 @@ describe('MbtiEngine', () => {
         assert.ok(fired, 'Event did not fire');
         assert.strictEqual(fired.trait, 'J');
         assert.strictEqual(fired.entity, entity);
+        assert.strictEqual(fired.tfUsed, false);
     });
 
     test('cooldown prevents rapid fire', () => {
@@ -21,10 +22,12 @@ describe('MbtiEngine', () => {
         const engine = new MbtiEngine(eventManager);
         const entity = { properties: { mbti: 'ESTJ' } };
         let count = 0;
-        eventManager.subscribe('ai_mbti_trait_triggered', () => { count++; });
+        let flag = null;
+        eventManager.subscribe('ai_mbti_trait_triggered', data => { count++; flag = data.tfUsed; });
         const action = { type: 'move', target: {}, context: { allies: [] } };
         engine.process(entity, action);
         engine.process(entity, action); // cooldown should block this
         assert.strictEqual(count, 1);
+        assert.strictEqual(flag, false);
     });
 });


### PR DESCRIPTION
## Summary
- publish whether MBTI trait came from TensorFlow
- show `(tf)` next to trait popup when TensorFlow was used
- update MBTI engine tests for new event field

## Testing
- `npm test` *(fails: Cannot find package '@tensorflow/tfjs')*

------
https://chatgpt.com/codex/tasks/task_e_6858c7d2542c8327a138401bb1ee513a