### PR TITLE
Fix TensorFlow model loading in browser

### DIFF
--- a/src/utils/tf-loader.js
+++ b/src/utils/tf-loader.js
@@ -24,14 +24,32 @@ export async function loadTf() {
 
 export async function loadCocoSsd() {
     if (!loadCocoSsd.promise) {
-        loadCocoSsd.promise = import('@tensorflow-models/coco-ssd');
+        if (typeof window !== 'undefined') {
+            loadCocoSsd.promise = import(
+                'https://cdn.jsdelivr.net/npm/@tensorflow-models/coco-ssd@2.2.3/dist/coco-ssd.esm.js'
+            ).catch(err => {
+                console.warn('[tf-loader] Failed to load coco-ssd', err);
+                throw err;
+            });
+        } else {
+            loadCocoSsd.promise = import('@tensorflow-models/coco-ssd');
+        }
     }
     return loadCocoSsd.promise;
 }
 
 export async function loadKnnClassifier() {
     if (!loadKnnClassifier.promise) {
-        loadKnnClassifier.promise = import('@tensorflow-models/knn-classifier');
+        if (typeof window !== 'undefined') {
+            loadKnnClassifier.promise = import(
+                'https://cdn.jsdelivr.net/npm/@tensorflow-models/knn-classifier@1.2.6/dist/knn-classifier.esm.js'
+            ).catch(err => {
+                console.warn('[tf-loader] Failed to load knn-classifier', err);
+                throw err;
+            });
+        } else {
+            loadKnnClassifier.promise = import('@tensorflow-models/knn-classifier');
+        }
     }
     return loadKnnClassifier.promise;
 }


### PR DESCRIPTION
## Summary
- support CDN fallback for coco-ssd and knn-classifier in `tf-loader`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858c8ef3a8883278f857a5b7cf0bea7