### PR TITLE
Add equip prompt for all inventory items

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -999,10 +999,7 @@ export class Game {
                 const item = gameState.inventory[itemIndex];
                 if (!item) return;
 
-                if (item.tags.includes('weapon') || item.tags.includes('armor') ||
-                    item.type === 'weapon' || item.type === 'armor') {
-                    this.uiManager._showEquipTargetPanel(item, gameState);
-                } else if (item.baseId === 'potion' || item.name === 'potion') {
+                if (item.baseId === 'potion' || item.name === 'potion') {
                     const playerChar = gameState.player;
                     playerChar.hp = Math.min(playerChar.maxHp, playerChar.hp + 5);
                     this.particleDecoratorManager.playHealingEffect(playerChar);
@@ -1013,6 +1010,9 @@ export class Game {
                     }
                 } else if (item.tags.includes('pet') || item.type === 'pet') {
                     this.petManager.equip(gameState.player, item, 'fox');
+                } else {
+                    // 무기를 포함한 모든 장비는 장착 대상 선택 UI를 사용합니다.
+                    this.uiManager._showEquipTargetPanel(item, gameState);
                 }
                 this.uiManager.renderInventory(gameState);
             },

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -668,10 +668,7 @@ export class UIManager {
         const item = gameState.inventory[itemIndex];
         if (!item) return;
 
-        if (item.tags.includes('weapon') || item.tags.includes('armor') ||
-            item.type === 'weapon' || item.type === 'armor') {
-            this._showEquipTargetPanel(item, gameState);
-        } else if (item.baseId === 'potion' || item.name === 'potion') {
+        if (item.baseId === 'potion' || item.name === 'potion') {
             const player = gameState.player;
             player.hp = Math.min(player.maxHp, player.hp + 5);
             console.log(`포션을 사용했습니다! HP +5`);
@@ -687,6 +684,9 @@ export class UIManager {
                 gameState.inventory.splice(itemIndex, 1);
             }
             this.updateUI(gameState);
+        } else {
+            // 무기를 제외한 나머지 아이템도 장착 대상 선택 UI를 표시합니다.
+            this._showEquipTargetPanel(item, gameState);
         }
     }
 


### PR DESCRIPTION
## Summary
- ask for target when using any inventory item (unless potion or pet)
- trigger equip prompt in game logic as well

## Testing
- `npm test` *(fails: Cannot find package '@tensorflow/tfjs')*

------
https://chatgpt.com/codex/tasks/task_e_6858d0361dd48327b169ec18375a1072