### PR TITLE
Load TensorFlow libs via script tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <title>타일 크롤러</title>
     <link rel="stylesheet" href="style.css">
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.20.0/dist/tf.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/coco-ssd@2.2.3/dist/coco-ssd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/knn-classifier@1.2.5/dist/knn-classifier.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-vis@1.5.1/dist/tfjs-vis.umd.min.js"></script>
 </head>
 <body>
     <div id="top-menu-bar" class="ui-frame">

--- a/src/managers/ai/CombatDecisionEngine.js
+++ b/src/managers/ai/CombatDecisionEngine.js
@@ -1,10 +1,10 @@
-import { loadTf } from '../../utils/tf-loader.js';
+import tfLoader from '../../utils/tf-loader.js';
 
 export class CombatDecisionEngine {
     constructor() {
         this.tf = null;
         this.model = null;
-        loadTf().then(tf => { this.tf = tf; this._init(); }).catch(() => {});
+        tfLoader.init().then(() => { this.tf = tfLoader.getTf(); this._init(); }).catch(() => {});
     }
 
     _init() {

--- a/src/managers/ai/MbtiEngine.js
+++ b/src/managers/ai/MbtiEngine.js
@@ -1,4 +1,4 @@
-import { loadTf, loadCocoSsd, loadKnnClassifier } from '../../utils/tf-loader.js';
+import tfLoader from '../../utils/tf-loader.js';
 
 export class MbtiEngine {
     constructor(eventManager, options = {}) {
@@ -13,14 +13,12 @@ export class MbtiEngine {
         this.tf = null;
         this.coco = null;
         this.knn = null;
-        loadTf().then(tf => { this.tf = tf; }).catch(err => {
-            console.warn('[MbtiEngine] Failed to load TensorFlow.js:', err);
-        });
-        loadCocoSsd().then(mod => { this.coco = mod; }).catch(err => {
-            console.warn('[MbtiEngine] Failed to load coco-ssd:', err);
-        });
-        loadKnnClassifier().then(mod => { this.knn = mod; }).catch(err => {
-            console.warn('[MbtiEngine] Failed to load knn-classifier:', err);
+        tfLoader.init().then(() => {
+            this.tf = tfLoader.getTf();
+            this.coco = tfLoader.cocoSsd;
+            this.knn = tfLoader.knnClassifier;
+        }).catch(err => {
+            console.warn('[MbtiEngine] Failed to initialize TensorFlow libraries:', err);
         });
 
         if (options.model) {
@@ -36,7 +34,8 @@ export class MbtiEngine {
     }
 
     async loadModel(url) {
-        const tf = this.tf || await loadTf();
+        await tfLoader.init();
+        const tf = this.tf || tfLoader.getTf();
         this.model = await tf.loadLayersModel(url);
         this.modelLoaded = true;
         console.log(`[MbtiEngine] Model loaded from ${url}`);

--- a/src/managers/pathfindingManager.js
+++ b/src/managers/pathfindingManager.js
@@ -1,5 +1,5 @@
 // src/pathfindingManager.js
-import { loadTf } from '../utils/tf-loader.js';
+import tfLoader from '../utils/tf-loader.js';
 
 export class PathfindingManager {
     constructor(mapManager) {
@@ -124,7 +124,8 @@ export class PathfindingManager {
 
     async findPathTensor(startX, startY, endX, endY) {
         try {
-            const tf = await loadTf();
+            await tfLoader.init();
+            const tf = tfLoader.getTf();
             if (!this.model) {
                 this.model = await tf.loadLayersModel('./assets/pathfinding-model.json');
             }


### PR DESCRIPTION
## Summary
- load TensorFlow libraries directly via `<script>` tags in `index.html`
- reference global TensorFlow objects in `tf-loader`
- update AI and pathfinding managers to use the new loader

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858d42a0bfc83279ca5669427266d00