### PR TITLE
Implement data recorder for AI training

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,16 +78,19 @@ npm install
 await metaAIManager.mbtiEngine.loadModel('models/mbti-model/model.json');
 ```
 
-데이터 수집을 위해 Node 환경에서 실행할 경우 `DataRecorder`를 활성화할 수 있습니다.
-`EventManager` 인스턴스 후 다음과 같이 초기화하세요:
+게임은 기본적으로 `DataRecorder`를 통해 플레이어의 행동을 실시간으로 수집합니다.
+브라우저에서는 `D` 키를 눌러 저장된 데이터를 `training_data.json` 파일로 다운로드할 수 있습니다.
+
+Node 환경에서 직접 파일로 기록하고 싶다면 다음과 같이 초기화합니다:
 
 ```javascript
-import { DataRecorder } from './src/managers/dataRecorder.js';
-const recorder = new DataRecorder(eventManager, './logs/sim.csv', 'csv');
+import DataRecorder from './src/managers/dataRecorder.js';
+const game = createGame();
+const recorder = new DataRecorder(game, './logs/training.jsonl');
+await recorder.init();
 ```
 
-기본 포맷은 JSONL이며, 두 번째 인수로 경로와 세 번째 인수로 `csv` 혹은 `json` 형식을
-선택할 수 있습니다.
+기본 포맷은 JSONL이며 `training.jsonl` 파일에 누적 기록됩니다.
 
 
 ## 결함 주입 테스트

--- a/src/data/ai-actions.js
+++ b/src/data/ai-actions.js
@@ -1,0 +1,9 @@
+export const AI_ACTIONS = [
+    'ATTACK',           // 일반 공격
+    'MOVE_TO_ENEMY',    // 적에게 접근
+    'FLEE',             // 후퇴
+    'PICKUP_WEAPON',    // 무기 줍기
+    'PICKUP_CONSUMABLE',// 소모품 줍기
+    'THROW_WEAPON',     // 무기 던지기 (위험할 때)
+    'IDLE',             // 아무것도 안 함 (대기)
+];

--- a/src/game.js
+++ b/src/game.js
@@ -37,6 +37,7 @@ import { Ghost } from './entities.js';
 import { TankerGhostAI, RangedGhostAI, SupporterGhostAI, CCGhostAI } from './ai.js';
 import { EMBLEMS } from './data/emblems.js';
 import { adjustMonsterStatsForAquarium } from './utils/aquariumUtils.js';
+import DataRecorder from './managers/dataRecorder.js';
 
 const MBTI_THOUGHTS = {
     E: ["함께 공격!", "내가 앞장서지!", "혼자가 아니야!"],
@@ -111,7 +112,7 @@ export class Game {
 
         // === 1. 모든 매니저 및 시스템 생성 ===
         this.eventManager = new EventManager();
-        this.inputHandler = new InputHandler(this.eventManager);
+        this.inputHandler = new InputHandler(this.eventManager, this);
         this.combatLogManager = new CombatLogManager(this.eventManager);
         this.systemLogManager = new SystemLogManager(this.eventManager);
         this.tagManager = new TagManager();
@@ -205,6 +206,8 @@ export class Game {
         this.uiManager.particleDecoratorManager = this.particleDecoratorManager;
         this.uiManager.vfxManager = this.vfxManager;
         this.metaAIManager = new MetaAIManager(this.eventManager);
+        this.dataRecorder = new DataRecorder(this);
+        this.dataRecorder.init();
         this.possessionAIManager = new PossessionAIManager(this.eventManager);
         this.itemFactory.emblems = EMBLEMS;
 

--- a/src/inputHandler.js
+++ b/src/inputHandler.js
@@ -1,14 +1,10 @@
 export class InputHandler {
-    constructor(eventManager) {
+    constructor(eventManager, game) {
+        this.eventManager = eventManager;
+        this.game = game;
         this.keysPressed = {};
 
-        document.addEventListener('keydown', (event) => {
-            this.keysPressed[event.key] = true;
-            // '1', '2' 같은 즉시 반응해야 하는 키는 여기서 이벤트 발행 가능
-            if (['1', '2', '3', '4'].includes(event.key)) {
-                eventManager.publish('key_pressed', { key: event.key });
-            }
-        });
+        document.addEventListener('keydown', (event) => this.handleKeyDown(event));
 
         document.addEventListener('keyup', (event) => {
             delete this.keysPressed[event.key];
@@ -17,7 +13,22 @@ export class InputHandler {
         document.addEventListener('wheel', (event) => {
             event.preventDefault();
             const direction = Math.sign(event.deltaY);
-            eventManager.publish('mouse_wheel', { direction });
+            this.eventManager.publish('mouse_wheel', { direction });
         }, { passive: false });
+    }
+
+    handleKeyDown(e) {
+        this.keysPressed[e.key] = true;
+        switch (e.key) {
+            case 'd': // 'D' 키를 누르면 데이터 다운로드
+                this.game?.dataRecorder?.downloadData();
+                break;
+            default:
+                break;
+        }
+        // '1', '2' 같은 즉시 반응해야 하는 키는 여기서 이벤트 발행 가능
+        if (['1', '2', '3', '4'].includes(e.key)) {
+            this.eventManager.publish('key_pressed', { key: e.key });
+        }
     }
 }

--- a/src/managers/ai/MbtiEngine.js
+++ b/src/managers/ai/MbtiEngine.js
@@ -56,7 +56,7 @@ export class MbtiEngine {
         this.cooldownCounter = this.cooldown;
     }
 
-    _buildInput(entity, action, game) {
+    buildInput(entity, action, game) {
         // 1. 현재 체력 비율 계산
         const healthPercentage = entity.hp / entity.maxHp;
 
@@ -136,8 +136,8 @@ export class MbtiEngine {
 
         if (this.tf && this.model) {
 
-            // _buildInput에 game 객체를 전달합니다.
-            const tensor = this._buildInput(entity, action, game);
+            // buildInput에 game 객체를 전달합니다.
+            const tensor = this.buildInput(entity, action, game);
             const trait = this._predictTrait(tensor);
 
             if (trait) {

--- a/src/managers/dataRecorder.js
+++ b/src/managers/dataRecorder.js
@@ -1,35 +1,101 @@
-import { appendFileSync, writeFileSync } from 'fs';
+// src/managers/dataRecorder.js
 
-export class DataRecorder {
-    constructor(eventManager, filePath = 'record.jsonl', format = 'json') {
-        this.filePath = filePath;
-        this.format = format;
-        try {
-            writeFileSync(this.filePath, '', { flag: 'w' });
-        } catch (e) {
-            console.error('Failed to initialize data recorder file', e);
-        }
-        const events = ['log', 'damage_calculated', 'simulation_step'];
-        events.forEach(evt => eventManager.subscribe(evt, data => this.write(evt, data)));
-    }
+import { AI_ACTIONS } from "../data/ai-actions.js";
 
-    write(eventName, data = {}) {
-        try {
-            const line = this.format === 'csv'
-                ? this.toCSV({ event: eventName, ...data })
-                : JSON.stringify({ event: eventName, ...data });
-            appendFileSync(this.filePath, line + '\n');
-        } catch (e) {
-            console.error('Failed to record data', e);
-        }
-    }
-
-    toCSV(obj) {
-        return Object.values(obj).map(v => {
-            if (typeof v === 'object') {
-                return JSON.stringify(v);
-            }
-            return String(v).replace(/,/g, ';');
-        }).join(',');
+// Node 환경에서는 fs 모듈을 사용해 바로 파일로 기록할 수 있다.
+let nodeFS = null;
+if (typeof window === 'undefined') {
+    try {
+        nodeFS = await import('fs');
+    } catch (e) {
+        nodeFS = null;
     }
 }
+
+class DataRecorder {
+    constructor(game, filePath = 'training_data.jsonl', format = 'json') {
+        this.game = game;
+        this.eventManager = game.eventManager;
+        this.filePath = filePath;
+        this.format = format;
+        this.data = [];
+        this.isRecording = true;
+        this.fs = null;
+    }
+
+    async init() {
+        // Node 환경이면 fs 모듈을 초기화하고 파일을 새로 만든다.
+        if (nodeFS) {
+            this.fs = nodeFS;
+            this.fs.writeFileSync(this.filePath, '', { flag: 'w' });
+        }
+
+        // 플레이어가 행동할 때마다 기록
+        this.eventManager.subscribe('player_action_recorded', ({ entity, action }) => {
+            if (this.isRecording) {
+                this.record(entity, action);
+            }
+        });
+
+        console.log('[DataRecorder] Now recording player actions for AI training.');
+    }
+
+    record(entity, action) {
+        const inputTensor = this.game.metaAIManager.mbtiEngine.buildInput(entity, action, this.game);
+        const input = inputTensor.arraySync()[0];
+
+        const output = Array(AI_ACTIONS.length).fill(0);
+        let actionName = action.type.toUpperCase();
+        if (action.type === 'pickup') {
+            actionName = action.item.type === 'weapon' ? 'PICKUP_WEAPON' : 'PICKUP_CONSUMABLE';
+        }
+
+        const actionIndex = AI_ACTIONS.indexOf(actionName);
+        if (actionIndex > -1) {
+            output[actionIndex] = 1;
+            const record = { input, output };
+            this.data.push(record);
+
+            if (this.fs) {
+                const line = this.format === 'csv'
+                    ? [...input, ...output].join(',')
+                    : JSON.stringify(record);
+                this.fs.appendFileSync(this.filePath, line + '\n');
+            }
+
+            console.log(`[DataRecorder] Recorded action: ${actionName}`, record);
+        } else {
+            console.warn(`[DataRecorder] Unknown action type for recording: ${action.type}`);
+        }
+    }
+
+    downloadData() {
+        if (this.data.length === 0) {
+            console.warn('[DataRecorder] No data to download.');
+            return;
+        }
+
+        const dataStr = JSON.stringify(this.data, null, 2);
+
+        // Node 환경에서는 지정된 파일 경로로 저장한다.
+        if (this.fs) {
+            this.fs.writeFileSync(this.filePath, dataStr);
+            console.log(`[DataRecorder] Data saved to ${this.filePath}.`);
+            return;
+        }
+
+        // 브라우저 환경이라면 다운로드 링크를 생성한다.
+        const dataBlob = new Blob([dataStr], { type: 'application/json' });
+        const url = URL.createObjectURL(dataBlob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'training_data.json';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+        console.log(`[DataRecorder] Downloaded ${this.data.length} records.`);
+    }
+}
+
+export default DataRecorder;

--- a/tests/dataRecorder.test.js
+++ b/tests/dataRecorder.test.js
@@ -1,23 +1,27 @@
 import { EventManager } from '../src/managers/eventManager.js';
-import { DataRecorder } from '../src/managers/dataRecorder.js';
-import { existsSync, readFileSync, unlinkSync } from 'fs';
+import DataRecorder from '../src/managers/dataRecorder.js';
 import { describe, test, assert } from './helpers.js';
 
-const DATA_PATH = './tests/tmp-data.jsonl';
+function createMockGame() {
+    const eventManager = new EventManager();
+    const mockMbti = {
+        buildInput: () => ({ arraySync: () => [[0, 0, 0, 0, 0]] })
+    };
+    return {
+        eventManager,
+        metaAIManager: { mbtiEngine: mockMbti }
+    };
+}
 
 describe('DataRecorder', () => {
-    test('records events to file', () => {
-        if (existsSync(DATA_PATH)) unlinkSync(DATA_PATH);
-        const eventManager = new EventManager();
-        new DataRecorder(eventManager, DATA_PATH, 'json');
-        eventManager.publish('log', { message: 'hello' });
-        eventManager.publish('damage_calculated', { damage: 5 });
-        eventManager.publish('simulation_step', { step: 1 });
-        const content = readFileSync(DATA_PATH, 'utf-8').trim().split('\n');
-        assert.strictEqual(content.length, 3);
-        const first = JSON.parse(content[0]);
-        assert.strictEqual(first.event, 'log');
-        assert.strictEqual(first.message, 'hello');
-        unlinkSync(DATA_PATH);
+    test('records player actions', async () => {
+        const game = createMockGame();
+        const recorder = new DataRecorder(game);
+        await recorder.init();
+        const action = { type: 'attack' };
+        const entity = { hp: 10, maxHp: 10 };
+        game.eventManager.publish('player_action_recorded', { entity, action });
+        assert.strictEqual(recorder.data.length, 1);
+        assert.deepStrictEqual(recorder.data[0].output, [1,0,0,0,0,0,0]);
     });
 });


### PR DESCRIPTION
## Summary
- add AI action definitions
- support recording in browser or Node
- expose `buildInput` for reuse
- document new recording workflow in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858da8de35483278a074b3b35180f88