### PR TITLE
Update MBTI popup and throwing mechanic

### DIFF
--- a/config/gameSettings.js
+++ b/config/gameSettings.js
@@ -2,5 +2,7 @@ export const SETTINGS = {
     TILE_SIZE: 192,
     DEFAULT_ZOOM: 0.5,
     // 이동 속도는 StatManager의 'movement' 스탯으로부터 파생됩니다.
+    // 자동 플레이 여부 (플레이어를 AI가 조종하도록 할지 여부)
+    autoPlay: false,
     // ... 나중에 더 많은 설정 추가
 };

--- a/src/combat.js
+++ b/src/combat.js
@@ -149,3 +149,36 @@ export class CombatCalculator {
         }
     }
 }
+
+/**
+ * '무기 던지기' 공격을 수행한다.
+ * 체력이 30% 미만일 때만 사용 가능하며, 무게에 비례한 추가 피해를 준다.
+ * @param {object} game - 게임 인스턴스
+ * @param {object} attacker - 공격자
+ * @param {object} target - 목표물
+ */
+export function performThrowWeaponAttack(game, attacker, target) {
+    const weapon = game.equipmentManager.getWeapon(attacker);
+    if (!weapon) {
+        console.log(`${attacker.name} has no weapon to throw.`);
+        return;
+    }
+
+    const healthPercentage = attacker.hp / attacker.maxHp;
+    if (healthPercentage >= 0.3) {
+        console.log(`${attacker.name} is not desperate enough to throw weapon. (HP: ${Math.floor(healthPercentage * 100)}%)`);
+        // 절박하지 않으므로 일반 공격
+        game.combatCalculator.handleAttack({ attacker, defender: target, skill: null }, { knockbackEngine: game.knockbackEngine });
+        return;
+    }
+
+    console.log(`${attacker.name} uses Last Resort! Throws ${weapon.name}!`);
+    game.eventManager.publish('log', { message: `${attacker.name}이(가) 최후의 수단으로 ${weapon.name}을(를) 던집니다!`, color: 'red' });
+
+    game.equipmentManager.unequip(attacker, weapon.slot);
+
+    const damage = ((weapon.weight || 1) + (attacker.damageBonus || 0)) * 2;
+    game.projectileManager.throwItem(attacker, target, weapon, damage, game.itemManager);
+
+    game.eventManager.publish('entity_updated', { entity: attacker });
+}

--- a/src/game.js
+++ b/src/game.js
@@ -962,19 +962,19 @@ export class Game {
             }
         });
 
-        // AI가 성격 특성을 발동했을 때 텍스트 팝업으로 표시
+        // AI가 성격 특성을 발동했을 때 간단한 알파벳 팝업을 표시
         eventManager.subscribe('ai_mbti_trait_triggered', (data) => {
             if (this.vfxManager) {
-                const trait = data.trait;
-                const options = MBTI_THOUGHTS[trait];
-                let thoughtText = trait;
-
-                if (options) {
-                    thoughtText = options[Math.floor(Math.random() * options.length)];
-                }
-
-                const text = data.tfUsed ? `${thoughtText}(tf)` : thoughtText;
+                // TensorFlow 사용 여부에 따라 (tf) 표시를 추가한다
+                const text = data.tfUsed ? `${data.trait}(tf)` : data.trait;
                 this.vfxManager.addTextPopup(text, data.entity);
+            }
+        });
+
+        // 아이템을 주웠을 때 "PICK UP!" 팝업을 표시
+        eventManager.subscribe('item_picked_up', ({ entity, item }) => {
+            if (this.vfxManager) {
+                this.vfxManager.addTextPopup('PICK UP!', entity, { color: 'yellow' });
             }
         });
 
@@ -1229,7 +1229,8 @@ export class Game {
             playerGroup: this.playerGroup,
             monsterGroup: this.monsterGroup,
             speechBubbleManager: this.speechBubbleManager,
-            enemies: metaAIManager.groups['dungeon_monsters']?.members || []
+            enemies: metaAIManager.groups['dungeon_monsters']?.members || [],
+            game: this
         };
         metaAIManager.update(context);
         this.possessionAIManager.update(context);

--- a/src/managers/item-ai-manager.js
+++ b/src/managers/item-ai-manager.js
@@ -1,4 +1,5 @@
 import { CombatDecisionEngine } from './ai/CombatDecisionEngine.js';
+import { performThrowWeaponAttack } from '../combat.js';
 
 export class ItemAIManager {
     constructor(eventManager = null, projectileManager = null, vfxManager = null, effectManager = null) {
@@ -170,6 +171,7 @@ export class ItemAIManager {
                 if (ok) {
                     itemManager.removeItem(item);
                     equipmentManager.equip(entity, item, null);
+                    this.eventManager?.publish('item_picked_up', { entity, item });
                     break;
                 }
             }
@@ -190,21 +192,21 @@ export class ItemAIManager {
             if (ok) {
                 itemManager.removeItem(item);
                 entity.addConsumable?.(item);
+                this.eventManager?.publish('item_picked_up', { entity, item });
                 this._useItem(entity, item, entity);
             }
         }
     }
 
     _maybeThrowWeapon(entity, target, context) {
-        const { projectileManager, itemManager, equipmentManager } = context;
+        const { projectileManager, itemManager, equipmentManager, game } = context;
         const weapon = entity.equipment?.weapon;
-        if (!weapon || !projectileManager || !itemManager || !equipmentManager) return;
+        if (!weapon || !projectileManager || !itemManager || !equipmentManager || !game) return;
         const dist = Math.hypot(target.x - entity.x, target.y - entity.y);
         const hpRatio = entity.hp / entity.maxHp;
         const ok = this.decisionEngine.shouldThrowWeapon(hpRatio, dist, weapon.weight || 1);
         if (ok) {
-            equipmentManager.unequip(entity, 'weapon', null);
-            projectileManager.throwItem(entity, target, weapon, (weapon.weight || 1) + (entity.damageBonus || 0), itemManager);
+            performThrowWeaponAttack(game, entity, target);
         }
     }
 


### PR DESCRIPTION
## Summary
- revert MBTI popup text to single letters again
- show a yellow **PICK UP!** popup when an item is picked up
- disable auto play in `gameSettings`
- add `performThrowWeaponAttack` helper in `combat.js`
- generate item pickup events and use the helper in `ItemAIManager`

## Testing
- `npm test` *(fails: Cannot find package '@tensorflow/tfjs')*

------
https://chatgpt.com/codex/tasks/task_e_6858debf3fcc8327a4ca08242b9996da