### PR TITLE
Add action cooldown flag

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -30,6 +30,8 @@ class Entity {
         this.effects = []; // 적용중인 효과 목록 배열 추가
         this.unitType = 'generic'; // 기본 유닛 타입을 '일반'으로 설정
         this.possessedBy = null; // 빙의 상태를 저장할 속성
+        this.target = null;
+        this.canAct = true; // 행동 가능 여부
 
         // --- AI 상태 저장용 프로퍼티 ---
         this.aiState = null;      // 현재 AI의 상태 (예: 'retreating')
@@ -220,6 +222,22 @@ export class Player extends Entity {
         this.fullness = this.maxFullness;
         this.consumables = [];
         this.consumableCapacity = 4;
+    }
+
+    takeTurn(action, game) {
+        if (!this.canAct) {
+            console.log('Player cannot act yet.');
+            return;
+        }
+
+        this.canAct = false;
+        setTimeout(() => {
+            this.canAct = true;
+        }, 500);
+
+        if (game?.turnManager?.playerAction) {
+            game.turnManager.playerAction(this, action, game);
+        }
     }
 
     render(ctx) {

--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -215,6 +215,11 @@ export class MetaAIManager {
             for (const member of membersSorted) {
                 if (member.hp <= 0) continue;
 
+                if (!member.canAct) {
+                    if (typeof member.update === 'function') member.update(currentContext);
+                    continue;
+                }
+
                 // 에어본 상태이면, 이번 턴 행동을 건너뜀
                 if (Array.isArray(member.effects) && member.effects.some(e => e.id === 'airborne')) {
                     if (typeof member.update === 'function') member.update(currentContext);
@@ -259,6 +264,12 @@ export class MetaAIManager {
                 this.processMbti(member, { ...action, context: currentContext });
 
                 this.executeAction(member, action, currentContext);
+                if (action && action.type && action.type !== 'idle') {
+                    member.canAct = false;
+                    setTimeout(() => {
+                        member.canAct = true;
+                    }, 1000);
+                }
             }
         }
     }

--- a/src/managers/metaAIManager.js
+++ b/src/managers/metaAIManager.js
@@ -53,6 +53,11 @@ export class MetaAIManager extends BaseMetaAI {
             for (const member of membersSorted) {
                 if (member.hp <= 0 || member.possessedBy) continue;
 
+                if (!member.canAct) {
+                    if (typeof member.update === 'function') member.update(currentContext);
+                    continue;
+                }
+
                 if (typeof member.update === 'function') {
                     member.update(currentContext);
                 } else if (member.attackCooldown > 0) {
@@ -71,6 +76,10 @@ export class MetaAIManager extends BaseMetaAI {
                     if (overrideAI) {
                         const action = overrideAI.decideAction(member, currentContext);
                         this.executeAction(member, action, currentContext);
+                        if (action && action.type && action.type !== 'idle') {
+                            member.canAct = false;
+                            setTimeout(() => { member.canAct = true; }, 1000);
+                        }
                         continue;
                     }
                 }
@@ -85,6 +94,10 @@ export class MetaAIManager extends BaseMetaAI {
                 if (member.ai) {
                     const action = member.ai.decideAction(member, currentContext);
                     this.executeAction(member, action, currentContext);
+                    if (action && action.type && action.type !== 'idle') {
+                        member.canAct = false;
+                        setTimeout(() => { member.canAct = true; }, 1000);
+                    }
                 }
             }
         }

--- a/src/managers/turnManager.js
+++ b/src/managers/turnManager.js
@@ -56,4 +56,33 @@ export class TurnManager {
             }
         }
     }
+
+    playerAction(entity, action, game) {
+        if (!game?.metaAIManager) return;
+        const context = {
+            eventManager: game.eventManager,
+            player: game.gameState.player,
+            mapManager: game.mapManager,
+            monsterManager: game.monsterManager,
+            mercenaryManager: game.mercenaryManager,
+            pathfindingManager: game.pathfindingManager,
+            motionManager: game.motionManager,
+            movementManager: game.movementManager,
+            projectileManager: game.projectileManager,
+            itemManager: game.itemManager,
+            equipmentManager: game.equipmentManager,
+            vfxManager: game.vfxManager,
+            knockbackEngine: game.knockbackEngine,
+            supportEngine: game.supportEngine,
+            assets: game.loader.assets,
+            metaAIManager: game.metaAIManager,
+            microItemAIManager: game.microItemAIManager,
+            playerGroup: game.playerGroup,
+            monsterGroup: game.monsterGroup,
+            speechBubbleManager: game.speechBubbleManager,
+            enemies: game.metaAIManager.groups['dungeon_monsters']?.members || [],
+            game
+        };
+        game.metaAIManager.executeAction(entity, action, context);
+    }
 }


### PR DESCRIPTION
## Summary
- add `canAct` flag for all entities
- respect the cooldown in MetaAIManager
- gate player actions through TurnManager

## Testing
- `npm test` *(fails: Cannot find package '@tensorflow/tfjs')*

------
https://chatgpt.com/codex/tasks/task_e_6858edeea780832792196c097b67c2af