### PR TITLE
Improve bard support logic

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -10,7 +10,7 @@ import { EMBLEMS } from './data/emblems.js';
 import { PREFIXES, SUFFIXES } from './data/affixes.js';
 import { JOBS } from './data/jobs.js';
 import { SKILLS } from './data/skills.js';
-import { MeleeAI, RangedAI, WizardAI, SummonerAI } from './ai.js';
+import { MeleeAI, RangedAI, WizardAI, SummonerAI, BardAI } from './ai.js';
 import { SupportAI } from './ai/SupportAI.js';
 import { SupportEngine } from './systems/SupportEngine.js';
 import { MBTI_TYPES } from './data/mbti.js';
@@ -130,11 +130,8 @@ export class CharacterFactory {
                         if (merc.stats) merc.stats.updateEquipmentStats();
                         if (typeof merc.updateAI === 'function') merc.updateAI();
                     }
-                    merc.roleAI = new SupportAI(this.supportEngine, {
-                        priorities: ['buff'],
-                        buffId: 'shield',
-                        skillIds: { buff: SKILLS.guardian_hymn.id }
-                    });
+                    merc.roleAI = new BardAI();
+                    merc.roleAI.engine = this.supportEngine;
                 } else {
                     const skillId = Math.random() < 0.5 ? SKILLS.double_strike.id : SKILLS.charge_attack.id;
                     merc.skills.push(skillId);


### PR DESCRIPTION
## Summary
- refine BardAI to keep MBTI-driven combat decisions while using hymns when needed
- ensure ranged allies return to player if they lose line of sight
- use BardAI when spawning bard mercenaries

## Testing
- `npm test` *(fails due to TensorFlow initialization issues)*

------
https://chatgpt.com/codex/tasks/task_e_68590935d26c832797d5033efd316ebb