### PR TITLE
Add role AI classes and cooldown checks

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -10,7 +10,7 @@ import { EMBLEMS } from './data/emblems.js';
 import { PREFIXES, SUFFIXES } from './data/affixes.js';
 import { JOBS } from './data/jobs.js';
 import { SKILLS } from './data/skills.js';
-import { MeleeAI, RangedAI, WizardAI, SummonerAI, BardAI } from './ai.js';
+import { MeleeAI, RangedAI, HealerAI, BardAI, SummonerAI, WizardAI, WarriorAI, ArcherAI } from './ai.js';
 import { SupportAI } from './ai/SupportAI.js';
 import { SupportEngine } from './systems/SupportEngine.js';
 import { MBTI_TYPES } from './data/mbti.js';
@@ -95,8 +95,7 @@ export class CharacterFactory {
                 merc.fallbackAI = new MeleeAI();
 
                 if (config.jobId === 'archer') {
-                    const rangedSkill = Math.random() < 0.5 ? SKILLS.double_thrust.id : SKILLS.hawk_eye.id;
-                    merc.skills.push(rangedSkill);
+                    merc.skills.push(SKILLS.double_strike.id);
                     const bow = this.itemFactory.create('long_bow', 0, 0, tileSize);
                     if (bow) {
                         merc.equipment.weapon = bow;
@@ -104,8 +103,10 @@ export class CharacterFactory {
                         if (typeof merc.updateAI === 'function') merc.updateAI();
                     }
                     merc.fallbackAI = new RangedAI();
+                    merc.roleAI = new ArcherAI();
                 } else if (config.jobId === 'warrior') {
                     merc.skills.push(SKILLS.charge_attack.id);
+                    merc.roleAI = new WarriorAI();
                 } else if (config.jobId === 'healer') {
                     merc.skills.push(SKILLS.heal.id);
                     merc.skills.push(SKILLS.purify.id);

--- a/src/micro/WeaponAI.js
+++ b/src/micro/WeaponAI.js
@@ -26,6 +26,7 @@ export class SwordAI extends BaseWeaponAI {
 
         if (
             weapon?.weaponStats?.canUseSkill('parry_stance') &&
+            (wielder.skillCooldowns['parry_stance'] || 0) <= 0 &&
             minDist <= wielder.attackRange &&
             wielder.attackCooldown > 0
         ) {
@@ -74,7 +75,12 @@ export class BowAI extends BaseWeaponAI {
         }
 
         const chargeSkillId = 'charge_shot';
-        if (weapon.weaponStats?.canUseSkill(chargeSkillId) && distance <= wielder.attackRange && distance > wielder.attackRange*0.5) {
+        if (
+            weapon.weaponStats?.canUseSkill(chargeSkillId) &&
+            (wielder.skillCooldowns[chargeSkillId] || 0) <= 0 &&
+            distance <= wielder.attackRange &&
+            distance > wielder.attackRange * 0.5
+        ) {
             return { type: 'weapon_skill', skillId: chargeSkillId, target: wielder };
         }
 
@@ -105,7 +111,12 @@ export class SpearAI extends BaseWeaponAI {
             const chargeData = WEAPON_SKILLS[chargeSkillId];
             const chargeRange = chargeData.range || 200;
 
-            if (weapon.weaponStats?.canUseSkill(chargeSkillId) && minDistance > wielder.attackRange && minDistance <= chargeRange) {
+            if (
+                weapon.weaponStats?.canUseSkill(chargeSkillId) &&
+                (wielder.skillCooldowns[chargeSkillId] || 0) <= 0 &&
+                minDistance > wielder.attackRange &&
+                minDistance <= chargeRange
+            ) {
                 return { type: 'weapon_skill', skillId: chargeSkillId, target: nearestTarget };
             }
 
@@ -187,6 +198,7 @@ export class WhipAI extends SpearAI {
 
         if (
             weapon.weaponStats.canUseSkill(pullSkillId) &&
+            (wielder.skillCooldowns[pullSkillId] || 0) <= 0 &&
             distance > wielder.attackRange &&
             distance <= pullSkillData.range
         ) {


### PR DESCRIPTION
## Summary
- support nearest enemy helper for AI archetypes
- add warrior and archer job AIs
- hook up new role AI when creating mercenaries
- ensure weapon AIs respect skill cooldowns
- fine tune warrior charge distance logic

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68590b7212648327aec0c070dd1930bf