### PR TITLE
Add bard skill usage and vision range tests

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -794,8 +794,24 @@ export class BardAI extends AIArchetype {
     decideAction(self, context) {
         const { player, allies, enemies, mapManager } = context;
         const mbti = self.properties?.mbti || '';
-        // 더 이상 음유시인은 스킬을 사용하지 않는다. 버프 대상을 찾거나
-        // 마나 및 쿨다운을 확인하는 로직을 모두 제거하여 기본 공격과 이동만 수행한다.
+        const guardianTarget = this.engine?.findBuffTarget(self, allies, 'shield');
+        const courageTarget = this.engine?.findBuffTarget(self, allies, 'bonus_damage');
+
+        if (
+            guardianTarget &&
+            self.skillCooldowns[SKILLS.guardian_hymn.id] <= 0 &&
+            self.mp >= SKILLS.guardian_hymn.manaCost
+        ) {
+            return { type: 'skill', target: guardianTarget, skillId: SKILLS.guardian_hymn.id };
+        }
+
+        if (
+            courageTarget &&
+            self.skillCooldowns[SKILLS.courage_hymn.id] <= 0 &&
+            self.mp >= SKILLS.courage_hymn.manaCost
+        ) {
+            return { type: 'skill', target: courageTarget, skillId: SKILLS.courage_hymn.id };
+        }
 
         const visible = this._filterVisibleEnemies(self, enemies);
         if (visible.length > 0) {

--- a/tests/bardSkills.integration.test.js
+++ b/tests/bardSkills.integration.test.js
@@ -1,0 +1,69 @@
+import { describe, test, assert } from './helpers.js';
+import { EventManager } from '../src/managers/eventManager.js';
+import { MetaAIManager, STRATEGY } from '../src/managers/ai-managers.js';
+import { CharacterFactory } from '../src/factory.js';
+import { SKILLS } from '../src/data/skills.js';
+
+// Bard should sequentially use both hymns when available
+
+describe('Integration', () => {
+  test('bard mercenary uses guardian and courage hymns', () => {
+    const assets = { player:{}, mercenary:{}, monster:{} };
+    const factory = new CharacterFactory(assets);
+    const eventManager = new EventManager();
+    const aiManager = new MetaAIManager(eventManager);
+
+    const playerGroup = aiManager.createGroup('player_party', STRATEGY.AGGRESSIVE);
+    const monsterGroup = aiManager.createGroup('dungeon_monsters', STRATEGY.AGGRESSIVE);
+
+    const player = factory.create('player', { x:0, y:0, tileSize:1, groupId:playerGroup.id });
+    player.ai = null;
+    playerGroup.addMember(player);
+
+    const bard = factory.create('mercenary', { x:0, y:0, tileSize:1, groupId:playerGroup.id, jobId:'bard' });
+    bard.mp = 50;
+    bard.skillCooldowns[SKILLS.guardian_hymn.id] = 0;
+    bard.skillCooldowns[SKILLS.courage_hymn.id] = 0;
+    playerGroup.addMember(bard);
+
+    player.effects = [];
+    bard.effects = [];
+
+    const monster = factory.create('monster', { x:5, y:0, tileSize:1, groupId:monsterGroup.id });
+    monsterGroup.addMember(monster);
+
+    const mapStub = { tileSize:1, isWallAt: () => false };
+    const context = {
+      player,
+      allies: [player, bard],
+      enemies: [monster],
+      mapManager: mapStub,
+      pathfindingManager: { findPath: () => [] },
+      eventManager,
+      movementManager: { moveEntityTowards(){} },
+      projectileManager: { create(){} },
+      microItemAIManager: { getWeaponAI(){ return null; } },
+      effectManager: { addEffect(){} },
+      motionManager: { },
+      vfxManager: { addTeleportEffect(_f,_t,cb){ if(cb) cb(); }, flashEntity(){}, addSpriteEffect(){}, addParticleBurst(){} },
+      speechBubbleManager: { addBubble(){} },
+    };
+
+    const actions = [];
+    aiManager.executeAction = (ent, action) => {
+      if (ent === bard) actions.push(action);
+    };
+
+    // first update - expect guardian hymn
+    aiManager.update(context);
+    assert.strictEqual(actions[0].skillId, SKILLS.guardian_hymn.id, 'first action should be guardian hymn');
+
+    // simulate shield effect so bard picks courage hymn next
+    player.effects.push({ id: 'shield' });
+    bard.effects.push({ id: 'shield' });
+
+    actions.length = 0;
+    aiManager.update(context);
+    assert.strictEqual(actions[0].skillId, SKILLS.courage_hymn.id, 'second action should be courage hymn');
+  });
+});

--- a/tests/mercenaryAI.integration.test.js
+++ b/tests/mercenaryAI.integration.test.js
@@ -65,7 +65,6 @@ describe('Integration', () => {
 
     assert.ok(actions[archer.id] && actions[archer.id].type !== 'idle', 'archer should act');
     assert.strictEqual(actions[healer.id].type, 'skill', 'healer should attempt to heal');
-    // 음유시인은 더 이상 스킬을 사용하지 않으므로 skill 타입이 아닌지 확인한다.
-    assert.notStrictEqual(actions[bard.id].type, 'skill', 'bard should not use skills');
+    assert.strictEqual(actions[bard.id].type, 'skill', 'bard should perform a hymn');
   });
 });

--- a/tests/mercenaryVisionRange.integration.test.js
+++ b/tests/mercenaryVisionRange.integration.test.js
@@ -1,0 +1,15 @@
+import { describe, test, assert } from './helpers.js';
+import { CharacterFactory } from '../src/factory.js';
+
+// verify all mercenaries share the same vision range
+
+describe('Integration', () => {
+  test('all mercenary jobs have the same vision range', () => {
+    const assets = { mercenary:{} };
+    const factory = new CharacterFactory(assets);
+    const jobs = ['warrior','archer','healer','wizard','summoner','bard'];
+    const ranges = jobs.map(job => factory.create('mercenary', { x:0, y:0, tileSize:1, groupId:'g', jobId:job }).visionRange);
+    const first = ranges[0];
+    ranges.forEach(r => assert.strictEqual(r, first));
+  });
+});


### PR DESCRIPTION
## Summary
- restore BardAI hymn logic
- expect bard to use skills in existing integration test
- add integration test for bard hymn usage order
- add integration test confirming equal vision range for all merc types

## Testing
- `npm install`
- `npm test` *(fails: TensorFlow JS initialization errors and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68591868bf10832785b3db7317619312