### PR TITLE
Fix BardAI skill usage

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -791,23 +791,29 @@ export class SummonerAI extends RangedAI {
 }
 
 export class BardAI extends AIArchetype {
+    constructor(game) {
+        super();
+        this.game = game;
+        this.supportEngine = game ? game.supportEngine : null;
+    }
+
     decideAction(self, context) {
         const { player, allies, enemies, mapManager } = context;
         const mbti = self.properties?.mbti || '';
-        const guardianTarget = this.engine?.findBuffTarget(self, allies, 'shield');
-        const courageTarget = this.engine?.findBuffTarget(self, allies, 'bonus_damage');
 
+        const guardianTarget = this.supportEngine?.findBuffTarget(self, allies, 'shield');
         if (
             guardianTarget &&
-            self.skillCooldowns[SKILLS.guardian_hymn.id] <= 0 &&
+            (self.skillCooldowns[SKILLS.guardian_hymn.id] || 0) <= 0 &&
             self.mp >= SKILLS.guardian_hymn.manaCost
         ) {
             return { type: 'skill', target: guardianTarget, skillId: SKILLS.guardian_hymn.id };
         }
 
+        const courageTarget = this.supportEngine?.findBuffTarget(self, allies, 'bonus_damage');
         if (
             courageTarget &&
-            self.skillCooldowns[SKILLS.courage_hymn.id] <= 0 &&
+            (self.skillCooldowns[SKILLS.courage_hymn.id] || 0) <= 0 &&
             self.mp >= SKILLS.courage_hymn.manaCost
         ) {
             return { type: 'skill', target: courageTarget, skillId: SKILLS.courage_hymn.id };

--- a/src/factory.js
+++ b/src/factory.js
@@ -131,8 +131,9 @@ export class CharacterFactory {
                         if (merc.stats) merc.stats.updateEquipmentStats();
                         if (typeof merc.updateAI === 'function') merc.updateAI();
                     }
-                    merc.roleAI = new BardAI();
-                    merc.roleAI.engine = this.supportEngine;
+                    // Pass the game object so BardAI can access SupportEngine safely
+                    const gameRef = this.game || { supportEngine: this.supportEngine };
+                    merc.roleAI = new BardAI(gameRef);
                 } else {
                     const skillId = Math.random() < 0.5 ? SKILLS.double_strike.id : SKILLS.charge_attack.id;
                     merc.skills.push(skillId);

--- a/tests/ai.test.js
+++ b/tests/ai.test.js
@@ -168,7 +168,7 @@ test('BardAI - attacks when songs unavailable', () => {
     const ai = new BardAI();
     const self = {
         x: 0, y: 0, visionRange: 100, attackRange: 10, speed: 5, tileSize: 1,
-        mp: 0, // not enough mana for songs
+        mp: 0,
         skills: ['guardian_hymn', 'courage_hymn'],
         skillCooldowns: {},
         equipment: { weapon: { tags: ['song'] } },


### PR DESCRIPTION
## Summary
- ensure bard role AI gets proper support engine through game reference
- restore BardAI combat logic so it attacks or moves when hymns unavailable
- revert unit tests to expect combat actions from BardAI when hymns can't be cast

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68591d75ff808327b80e72dd9833cfce