### PR TITLE
Implement universal Healer and Bard AI

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -110,10 +110,14 @@ export class CharacterFactory {
                 } else if (config.jobId === 'healer') {
                     merc.skills.push(SKILLS.heal.id);
                     merc.skills.push(SKILLS.purify.id);
-                    merc.roleAI = new SupportAI(this.supportEngine, {
-                        priorities: ['purify', 'heal'],
-                        skillIds: { heal: SKILLS.heal.id, purify: SKILLS.purify.id }
-                    });
+                    const weapon = this.itemFactory.create('short_sword', 0, 0, tileSize);
+                    if (weapon) {
+                        merc.equipment.weapon = weapon;
+                        if (merc.stats) merc.stats.updateEquipmentStats();
+                    }
+                    const gameRef = this.game || { supportEngine: this.supportEngine };
+                    merc.roleAI = new HealerAI(gameRef);
+                    merc.fallbackAI = null;
                 } else if (config.jobId === 'wizard') {
                     const mageSkill = Math.random() < 0.5 ? SKILLS.fireball.id : SKILLS.iceball.id;
                     merc.skills.push(mageSkill);

--- a/tests/embargo.test.js
+++ b/tests/embargo.test.js
@@ -11,7 +11,8 @@ import { MeleeAI, PurifierAI, HealerAI, CompositeAI } from '../src/ai.js';
 import { Item } from '../src/entities.js';
 import { SKILLS } from '../src/data/skills.js';
 import { describe, test, assert } from './helpers.js';
-import * as tf from '@tensorflow/tfjs';
+// TensorFlow is not needed in the test environment
+const tf = {};
 
 // 업데이트된 엠바고 테스트
 
@@ -104,8 +105,12 @@ test('차지 어택과 포션 사용 시나리오', () => {
      const mapManager = new MapManager(1);
      const factory = new CharacterFactory(assets);
      const player = factory.create('player', { x:0, y:0, tileSize:1, groupId:'g' });
-     const healer = factory.create('mercenary', { x:1, y:0, tileSize:1, groupId:'g', jobId:'healer' });
-     healer.ai = new CompositeAI(new PurifierAI(), new HealerAI());
+    const healer = factory.create('mercenary', { x:1, y:0, tileSize:1, groupId:'g', jobId:'healer' });
+    const supportEngine = {
+        findPurifyTarget(_s, allies){ return allies[0]; },
+        findHealTarget(){ return null; }
+    };
+    healer.ai = new CompositeAI(new PurifierAI(), new HealerAI({ supportEngine }));
      healer.properties.mbti = 'ESFJ';
      healer.mp = healer.maxMp;
      const monster = factory.create('monster', { x:2, y:0, tileSize:1, groupId:'m' });

--- a/tests/faultInjection.test.js
+++ b/tests/faultInjection.test.js
@@ -13,7 +13,8 @@ const mapStub = { tileSize: 1, isWallAt: () => false };
 describe('Fault Injection', () => {
 
     test('HealerAI handles invalid mbti string', () => {
-        const ai = new AI.HealerAI();
+        const supportEngine = { findHealTarget(){ return null; }, findPurifyTarget(){ return null; } };
+        const ai = new AI.HealerAI({ supportEngine });
         const self = {
             x: 0, y: 0, visionRange: 100, attackRange: 10, speed: 5, tileSize: 1,
             mp: 20, skills: ['heal'], skillCooldowns: {}, properties: { mbti: '????' }
@@ -25,7 +26,8 @@ describe('Fault Injection', () => {
     });
 
     test('HealerAI handles missing heal skill gracefully', () => {
-        const ai = new AI.HealerAI();
+        const supportEngine = { findHealTarget(){ return null; }, findPurifyTarget(){ return null; } };
+        const ai = new AI.HealerAI({ supportEngine });
         const self = {
             x: 0, y: 0, visionRange: 100, attackRange: 10, speed: 5, tileSize: 1,
             mp: 0, skills: [], skillCooldowns: {}, properties: { mbti: 'ENFP' }

--- a/tests/full-cycle.integration.test.js
+++ b/tests/full-cycle.integration.test.js
@@ -62,7 +62,7 @@ describe('Full Cycle Integration Test', () => {
       maxMp: 30,
       skills: ['heal'],
       skillCooldowns: {},
-      ai: new HealerAI(),
+      ai: new HealerAI({ supportEngine: { findHealTarget(){ return player; }, findPurifyTarget(){ return null; } } }),
       properties: { mbti: 'ESFJ' },
       stats: { get: () => 0 },
       attackRange: 192,

--- a/tests/healerHeal.test.js
+++ b/tests/healerHeal.test.js
@@ -9,7 +9,11 @@ describe('Healing', () => {
   test('healer skill restores ally hp', () => {
     const factory = new CharacterFactory(assets);
     const healer = factory.create('mercenary', { x:0, y:0, tileSize:1, groupId:'g', jobId:'healer' });
-    healer.ai = new HealerAI();
+    const supportEngine = { 
+      findHealTarget(_s, allies){ return allies[1]; },
+      findPurifyTarget(){ return null; }
+    };
+    healer.ai = new HealerAI({ supportEngine });
     healer.mp = healer.maxMp; // 충분한 마나 확보
     const ally = factory.create('mercenary', { x:5, y:0, tileSize:1, groupId:'g', jobId:'warrior' });
     ally.hp = ally.maxHp - 5; // 부상 입힘

--- a/tests/mercenaryAI.integration.test.js
+++ b/tests/mercenaryAI.integration.test.js
@@ -32,7 +32,7 @@ describe('Integration', () => {
     const archer = factory.create('mercenary', { x:1, y:0, tileSize:1, groupId:playerGroup.id, jobId:'archer' });
     const healer = factory.create('mercenary', { x:-1, y:0, tileSize:1, groupId:playerGroup.id, jobId:'healer' });
     // PurifierAI가 이동으로 가로채는 것을 막기 위해 HealerAI만 사용한다.
-    healer.roleAI = new HealerAI();
+    healer.roleAI = new HealerAI({ supportEngine: factory.supportEngine });
     const bard = factory.create('mercenary', { x:0, y:1, tileSize:1, groupId:playerGroup.id, jobId:'bard' });
     playerGroup.addMember(archer);
     playerGroup.addMember(healer);

--- a/tests/purify.test.js
+++ b/tests/purify.test.js
@@ -9,7 +9,11 @@ describe('Purify', () => {
   test('healer removes ailment from ally', () => {
     const factory = new CharacterFactory(assets);
     const healer = factory.create('mercenary', { x:0, y:0, tileSize:1, groupId:'g', jobId:'healer' });
-    healer.ai = new CompositeAI(new PurifierAI(), new HealerAI());
+    const supportEngine = { 
+      findPurifyTarget(_s, allies){ return allies[1]; },
+      findHealTarget(){ return null; }
+    };
+    healer.ai = new CompositeAI(new PurifierAI(), new HealerAI({ supportEngine }));
     healer.properties.mbti = 'ISFJ';
     healer.mp = healer.maxMp;
     const ally = factory.create('mercenary', { x:5, y:0, tileSize:1, groupId:'g', jobId:'warrior' });


### PR DESCRIPTION
## Summary
- equip healers with a short sword and switch to new `HealerAI`
- use updated universal `BardAI`
- replace old healer and bard AI logic with new prioritized versions
- adjust tests for new HealerAI constructor and remove MBTI logic
- remove TensorFlow dependency from embargo test
- ensure healer AI has proper SupportEngine reference

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859243b57048327974dacb794f788d7