### PR TITLE
Implement universal AI for wizard & summoner

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -121,11 +121,27 @@ export class CharacterFactory {
                 } else if (config.jobId === 'wizard') {
                     const mageSkill = Math.random() < 0.5 ? SKILLS.fireball.id : SKILLS.iceball.id;
                     merc.skills.push(mageSkill);
-                    merc.roleAI = new WizardAI();
+                    // ===== 마법사에게 기본 무기 장착 및 AI 수정 =====
+                    const weapon = this.itemFactory.create('short_sword', 0, 0, tileSize);
+                    if (weapon) {
+                        merc.equipment.weapon = weapon;
+                        if (merc.stats) merc.stats.updateEquipmentStats();
+                    }
+                    merc.roleAI = new WizardAI(this.game);
+                    merc.fallbackAI = null;
+                    // ===============================================
                 } else if (config.jobId === 'summoner') {
                     merc.skills.push(SKILLS.summon_skeleton.id);
                     merc.properties.maxMinions = 2;
-                    merc.roleAI = new SummonerAI();
+                    // ===== 소환사에게 기본 무기 장착 및 AI 수정 =====
+                    const weapon = this.itemFactory.create('short_sword', 0, 0, tileSize);
+                    if (weapon) {
+                        merc.equipment.weapon = weapon;
+                        if (merc.stats) merc.stats.updateEquipmentStats();
+                    }
+                    merc.roleAI = new SummonerAI(this.game);
+                    merc.fallbackAI = null;
+                    // ===============================================
                 } else if (config.jobId === 'bard') {
                     merc.skills.push(SKILLS.guardian_hymn.id);
                     merc.skills.push(SKILLS.courage_hymn.id);

--- a/tests/summonerAI.test.js
+++ b/tests/summonerAI.test.js
@@ -4,13 +4,15 @@ import { describe, test, assert } from './helpers.js';
 const mapStub = { tileSize: 1, isWallAt: () => false };
 
 describe('SummonerAI', () => {
-    test('uses summon skill when no minions', () => {
+    test('uses summon skill when enemy nearby and no minions', () => {
         const ai = new SummonerAI();
         const self = {
             x: 0, y: 0, visionRange: 50, attackRange: 10, speed: 5, tileSize: 1,
-            mp: 30, skills: ['summon_skeleton'], skillCooldowns: {}, properties: {}
+            mp: 30, skills: ['summon_skeleton'], skillCooldowns: {},
+            properties: { maxMinions: 1 }
         };
-        const context = { player: {}, allies: [self], enemies: [], mapManager: mapStub };
+        const enemy = { x: 5, y: 0 };
+        const context = { player: {}, allies: [self], enemies: [enemy], mapManager: mapStub };
         const action = ai.decideAction(self, context);
         assert.strictEqual(action.type, 'skill');
         assert.strictEqual(action.skillId, 'summon_skeleton');
@@ -22,7 +24,8 @@ describe('SummonerAI', () => {
             id: 'summoner1',
             x: 0, y: 0, visionRange: 50, attackRange: 10, speed: 5, tileSize: 1,
             mp: 30, skills: ['summon_skeleton'], skillCooldowns: {},
-            properties: { maxMinions: 2 }
+            properties: { maxMinions: 2 },
+            minions: [{}, {}]
         };
         const minion1 = { properties: { summonedBy: 'summoner1' } };
         const minion2 = { properties: { summonedBy: 'summoner1' } };


### PR DESCRIPTION
## Summary
- equip wizards and summoners with short swords by default
- give wizard and summoner mercenaries new WizardAI and SummonerAI
- update WizardAI and SummonerAI logic to handle all priorities
- adjust SummonerAI tests for updated enemy requirement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68592757f0348327adb18e7ee5b28e07