### PR TITLE
Add cinematic manager and slow motion

### DIFF
--- a/src/gameLoop.js
+++ b/src/gameLoop.js
@@ -2,8 +2,9 @@ export class GameLoop {
     constructor(update, render) {
         this.update = update;
         this.render = render;
-        this.lastTime = 0;
         this.isRunning = false;
+        this.lastTime = 0;
+        this.timeScale = 1.0;
     }
 
     start() {
@@ -18,10 +19,10 @@ export class GameLoop {
     loop = (currentTime) => {
         if (!this.isRunning) return;
 
-        const deltaTime = currentTime - this.lastTime;
+        const deltaTime = (currentTime - this.lastTime) / 1000;
         this.lastTime = currentTime;
 
-        this.update(deltaTime);
+        this.update(deltaTime * this.timeScale);
         this.render();
 
         requestAnimationFrame(this.loop);

--- a/src/managers/cinematicManager.js
+++ b/src/managers/cinematicManager.js
@@ -1,0 +1,50 @@
+export class CinematicManager {
+    constructor(game) {
+        this.game = game;
+        this.eventManager = game.eventManager;
+        this.isPlaying = false;
+        this.targetEntity = null;
+        this.targetZoom = 1;
+        this.originalZoom = 1;
+        this.originalTimeScale = 1;
+
+        this.init();
+    }
+
+    init() {
+        this.eventManager.subscribe('weapon_disarmed', (data) => {
+            this.triggerCinematic(data.defender, 'PARRIED!', 2000);
+        });
+        this.eventManager.subscribe('armor_broken', (data) => {
+            this.triggerCinematic(data.defender, 'ARMOR BREAK!', 2000);
+        });
+    }
+
+    triggerCinematic(target, text, duration) {
+        if (this.isPlaying) return;
+
+        this.isPlaying = true;
+        this.targetEntity = target;
+
+        this.originalZoom = this.game.gameState.zoomLevel;
+        this.originalTimeScale = this.game.gameLoop.timeScale;
+
+        this.targetZoom = this.originalZoom * 1.8;
+        this.game.gameLoop.timeScale = 0.2;
+
+        this.game.vfxManager.addCinematicText(text, duration);
+
+        setTimeout(() => {
+            this.reset();
+        }, duration);
+    }
+
+    reset() {
+        this.targetZoom = this.originalZoom;
+        this.game.gameLoop.timeScale = this.originalTimeScale;
+        this.targetEntity = null;
+        setTimeout(() => {
+            this.isPlaying = false;
+        }, 500);
+    }
+}

--- a/src/managers/vfx/TextPopupEngine.js
+++ b/src/managers/vfx/TextPopupEngine.js
@@ -37,10 +37,19 @@ export class TextPopupEngine {
         for (let i = this.popups.length - 1; i >= 0; i--) {
             const popup = this.popups[i];
             popup.life--;
-            popup.y -= popup.floatSpeed;
-            popup.alpha = popup.life / popup.duration;
+            if (popup.vy !== undefined) {
+                popup.y += popup.vy;
+            } else {
+                popup.y -= popup.floatSpeed;
+            }
 
-            if (popup.life <= 0) {
+            if (popup.fadeSpeed !== undefined) {
+                popup.alpha -= popup.fadeSpeed;
+            } else {
+                popup.alpha = popup.life / popup.duration;
+            }
+
+            if (popup.life <= 0 || popup.alpha <= 0) {
                 this.popups.splice(i, 1);
             }
         }
@@ -48,14 +57,22 @@ export class TextPopupEngine {
 
     render(ctx) {
         if (!ctx) return;
-        ctx.save();
         for (const popup of this.popups) {
+            ctx.save();
+            if (popup.isUI && ctx.setTransform) {
+                ctx.setTransform(1, 0, 0, 1, 0, 0);
+            }
             ctx.globalAlpha = popup.alpha;
-            ctx.fillStyle = popup.color;
+            ctx.fillStyle = popup.fillStyle || popup.color;
             ctx.font = popup.font;
-            ctx.textAlign = 'center';
+            ctx.textAlign = popup.alignment || 'center';
+            if (popup.strokeStyle) {
+                ctx.strokeStyle = popup.strokeStyle;
+                ctx.lineWidth = popup.lineWidth || 1;
+                ctx.strokeText(popup.text, popup.x, popup.y);
+            }
             ctx.fillText(popup.text, popup.x, popup.y);
+            ctx.restore();
         }
-        ctx.restore();
     }
 }

--- a/src/managers/vfxManager.js
+++ b/src/managers/vfxManager.js
@@ -284,6 +284,31 @@ export class VFXManager {
         this.textPopupEngine.add(text, target, options);
     }
 
+    addCinematicText(text, duration = 2000) {
+        const frames = Math.round(duration / 16.67);
+        const centerX = this.game.layerManager.layers.vfx.width / 2;
+        const centerY = this.game.layerManager.layers.vfx.height / 2;
+
+        const textEffect = {
+            text,
+            font: 'bold 72px Arial',
+            fillStyle: 'white',
+            strokeStyle: 'black',
+            lineWidth: 4,
+            x: centerX,
+            y: centerY,
+            vy: 0,
+            duration: frames,
+            life: frames,
+            isUI: true,
+            alignment: 'center',
+            alpha: 1.0,
+            fadeSpeed: 0.05
+        };
+
+        this.textPopupEngine.popups.push(textEffect);
+    }
+
     /**
      * 시전 이펙트: 지정 유닛 주변에서 파티클이 모여드는 애니메이션을 생성합니다.
      * 시전 속도가 빠를수록 파티클이 더 빠르게 모여듭니다.


### PR DESCRIPTION
## Summary
- add CinematicManager for slow motion cut-ins
- support time scaling in GameLoop
- hook CinematicManager into Game
- centralize camera/zoom handling for cinematic scenes
- add cinematic text function
- extend TextPopupEngine for richer text effects
- fix cinematic text life and render as UI overlay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68592cf813948327af6392e8bcbf73e3