### PR TITLE
Add MicroWorld cinematic zoom

### DIFF
--- a/src/managers/cinematicManager.js
+++ b/src/managers/cinematicManager.js
@@ -13,11 +13,15 @@ export class CinematicManager {
 
     init() {
         this.eventManager.subscribe('weapon_disarmed', (data) => {
-            this.triggerCinematic(data.defender, 'PARRIED!', 2000);
+            this.triggerMicroWorldJudgement(data.defender);
         });
         this.eventManager.subscribe('armor_broken', (data) => {
-            this.triggerCinematic(data.defender, 'ARMOR BREAK!', 2000);
+            this.triggerMicroWorldJudgement(data.defender);
         });
+    }
+
+    triggerMicroWorldJudgement(target) {
+        this.triggerCinematic(target, 'MICROWORLD JUDGEMENT!', 2000);
     }
 
     triggerCinematic(target, text, duration) {


### PR DESCRIPTION
## Summary
- trigger cinematic zoom when micro world combat results occur
- show text `MICROWORLD JUDGEMENT!` with slow motion effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68593adab7988327a1e3868edcc2f46e