### PR TITLE
Fix CinematicManager timescale

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -604,8 +604,8 @@ export class Game {
 
         this.setupEventListeners(assets, canvas);
 
-        const gameLoop = new GameLoop(this.update, this.render);
-        gameLoop.start();
+        this.gameLoop = new GameLoop(this.update, this.render);
+        this.gameLoop.start();
     }
 
     setupEventListeners(assets, canvas) {


### PR DESCRIPTION
## Summary
- assign `gameLoop` instance to the Game class
- keep cinematic manager from crashing when triggering cut scenes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685945825eb48327b2c5f76192024097