### PR TITLE
Fix mercenary idle spacing and add AI reset

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -36,7 +36,7 @@ export class AIArchetype {
 
                 // 동료와 너무 가까우면 살짝 밀어내기
                 for (const ally of allies) {
-                    if (ally === self) continue;
+                    if (ally === self || ally.isPlayer) continue;
                     const dx = x - ally.x;
                     const dy = y - ally.y;
                     const d = Math.hypot(dx, dy);

--- a/src/entities.js
+++ b/src/entities.js
@@ -247,6 +247,9 @@ export class Mercenary extends Entity {
         this.consumables = [];
         this.consumableCapacity = 4;
 
+        // 초기 역할 AI 보존용
+        this.defaultRoleAI = null;
+
 
         // 플레이어 주변을 배회하기 위한 프로퍼티
         // 약간의 랜덤성을 부여해 모든 용병이 동시에 움직이지 않도록 함
@@ -265,6 +268,12 @@ export class Mercenary extends Entity {
         item.quantity = 1;
         this.consumables.push(item);
         return true;
+    }
+
+    resetRoleAI() {
+        if (this.defaultRoleAI) {
+            this.roleAI = this.defaultRoleAI;
+        }
     }
 }
 

--- a/src/factory.js
+++ b/src/factory.js
@@ -104,9 +104,11 @@ export class CharacterFactory {
                     }
                     merc.fallbackAI = new RangedAI();
                     merc.roleAI = new ArcherAI(this.game);
+                    merc.defaultRoleAI = merc.roleAI;
                 } else if (config.jobId === 'warrior') {
                     merc.skills.push(SKILLS.charge_attack.id);
                     merc.roleAI = new WarriorAI(this.game);
+                    merc.defaultRoleAI = merc.roleAI;
                     const weapon = this.itemFactory.create('short_sword', 0, 0, tileSize);
                     if (weapon) {
                         merc.equipment.weapon = weapon;
@@ -122,6 +124,7 @@ export class CharacterFactory {
                     }
                     const gameRef = this.game || { supportEngine: this.supportEngine };
                     merc.roleAI = new HealerAI(gameRef);
+                    merc.defaultRoleAI = merc.roleAI;
                     merc.fallbackAI = null;
                 } else if (config.jobId === 'wizard') {
                     const mageSkill = Math.random() < 0.5 ? SKILLS.fireball.id : SKILLS.iceball.id;
@@ -133,6 +136,7 @@ export class CharacterFactory {
                         if (merc.stats) merc.stats.updateEquipmentStats();
                     }
                     merc.roleAI = new WizardAI(this.game);
+                    merc.defaultRoleAI = merc.roleAI;
                     merc.fallbackAI = null;
                     // ===============================================
                 } else if (config.jobId === 'summoner') {
@@ -145,6 +149,7 @@ export class CharacterFactory {
                         if (merc.stats) merc.stats.updateEquipmentStats();
                     }
                     merc.roleAI = new SummonerAI(this.game);
+                    merc.defaultRoleAI = merc.roleAI;
                     merc.fallbackAI = null;
                     // ===============================================
                 } else if (config.jobId === 'bard') {
@@ -159,6 +164,7 @@ export class CharacterFactory {
                     // Pass the game object so BardAI can access SupportEngine safely
                     const gameRef = this.game || { supportEngine: this.supportEngine };
                     merc.roleAI = new BardAI(gameRef);
+                    merc.defaultRoleAI = merc.roleAI;
                     merc.fallbackAI = null; // disable default AI for bards
                 } else {
                     const skillId = Math.random() < 0.5 ? SKILLS.double_strike.id : SKILLS.charge_attack.id;

--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -52,6 +52,12 @@ export class MetaAIManager {
         }
     }
 
+    resetRoleAI(entity) {
+        if (entity && typeof entity.resetRoleAI === 'function') {
+            entity.resetRoleAI();
+        }
+    }
+
     executeAction(entity, action, context) {
         if (!action || !action.type || action.type === 'idle') return;
         const { eventManager } = context;


### PR DESCRIPTION
## Summary
- disperse mercenaries better while wandering
- store default role AI and add method to reset to it
- export helper to reset role AI from MetaAIManager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68594969f7b08327b596f6da4ac95e8c