### PR TITLE
Remove cinematic item zoom

### DIFF
--- a/src/managers/cinematicManager.js
+++ b/src/managers/cinematicManager.js
@@ -13,17 +13,15 @@ export class CinematicManager {
 
     init() {
         this.eventManager.subscribe('weapon_disarmed', (data) => {
-            if (data.weapon) {
-                this.playItemCloseup(data.weapon);
-            } else {
-                this.triggerMicroWorldJudgement(data.defender);
+            const target = data.owner || data.defender;
+            if (target) {
+                this.triggerMicroWorldJudgement(target);
             }
         });
         this.eventManager.subscribe('armor_broken', (data) => {
-            if (data.armor) {
-                this.playItemCloseup(data.armor);
-            } else {
-                this.triggerMicroWorldJudgement(data.defender);
+            const target = data.owner || data.defender;
+            if (target) {
+                this.triggerMicroWorldJudgement(target);
             }
         });
     }


### PR DESCRIPTION
## Summary
- stop CinematicManager from zooming in on items when gear is disarmed or breaks
- keep micro world judgment text only

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68596137897c8327a4c61648af519221