### PR TITLE
Add haste buff skill

### DIFF
--- a/codex's room/dev-log.md
+++ b/codex's room/dev-log.md
@@ -60,3 +60,8 @@
 - 알파벳 상태 효과 8종을 `effects.js`에 추가.
 - `StatManager`가 상태 효과를 감지해 스탯 보너스를 적용하도록 수정.
 - 새 테스트 `alphabetState.test.js`로 이동 속도 증가를 확인.
+
+## 세션 14
+- 이동 속도 증가 버프 `haste` 효과 및 스킬 추가.
+- 스킬 목록 문서에 `haste` 항목을 기록.
+- `effectManager.test.js`에 신속 효과 테스트를 작성.

--- a/skills.md
+++ b/skills.md
@@ -19,6 +19,7 @@
 | regeneration_aura | 재생 오라 | buff, aura, passive |
 | meditation_aura | 명상 오라 | buff, aura, passive |
 | haste_aura | 가속 오라 | buff, aura, passive |
+| haste | 신속 | buff, speed_up |
 | concentration_aura | 집중 오라 | buff, aura, passive |
 | condemn_aura | 단죄 오라 | buff, aura, passive |
 | natural_aura | 자연 오라 | buff, aura, passive |

--- a/src/data/effects.js
+++ b/src/data/effects.js
@@ -134,6 +134,14 @@ export const EFFECTS = {
         tags: ['debuff', 'slow'],
     },
 
+    haste: {
+        name: '신속',
+        type: 'buff',
+        duration: 300,
+        stats: { movementSpeed: 1 },
+        tags: ['buff', 'speed_up'],
+    },
+
     charging_shot_effect: {
         name: '충전된 사격',
         type: 'buff',

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -257,6 +257,16 @@ export const SKILLS = {
         tags: ['skill', 'debuff', 'resist_down', 'enemy', '디버프'],
         effects: { target: ['resist_down'] },
     },
+
+    haste: {
+        id: 'haste',
+        name: '신속',
+        description: '아군의 이동 속도를 일시적으로 증가시킵니다.',
+        manaCost: 10,
+        cooldown: 120,
+        tags: ['skill', 'buff', 'speed_up', 'support'],
+        effects: { target: ['haste'] },
+    },
     summon_skeleton: {
         id: 'summon_skeleton',
         name: '해골 소환',

--- a/tests/effectManager.test.js
+++ b/tests/effectManager.test.js
@@ -57,4 +57,18 @@ test('동결 이동 속도 감소', () => {
     assert.strictEqual(stats.get('movementSpeed'), base);
 });
 
+test('신속 이동 속도 증가', () => {
+    const eventManager = new EventManager();
+    const effectManager = new EffectManager(eventManager);
+    const stats = new StatManager({}, { movement: 4 });
+    const target = { effects: [], stats, shield: 0, damageBonus: 0, takeDamage: () => {} };
+    const base = stats.get('movementSpeed');
+    effectManager.addEffect(target, 'haste');
+    stats.recalculate();
+    assert.strictEqual(stats.get('movementSpeed'), base + 1);
+    effectManager.removeEffect(target, target.effects[0]);
+    stats.recalculate();
+    assert.strictEqual(stats.get('movementSpeed'), base);
+});
+
 });


### PR DESCRIPTION
## Summary
- introduce `haste` effect increasing movement speed
- implement `haste` skill using the new effect
- document the new skill in the skills reference
- log development progress for session 14
- test haste effect in `effectManager`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859632051488327bd4545087daf7915