### PR TITLE
Implement Aspiration system for weapons

### DIFF
--- a/src/combat.js
+++ b/src/combat.js
@@ -76,6 +76,12 @@ export class CombatCalculator {
         }
         // --- 패링 로직 끝 ---
 
+        const accuracy = attacker.stats?.get?.('accuracy');
+        if (typeof accuracy === 'number' && Math.random() > accuracy) {
+            this.eventManager.publish('attack_missed', { attacker, defender, skill });
+            return;
+        }
+
         let finalDamage = 0;
         const details = { base: 0, fromSkill: 0, fromTags: 0, fromRunes: 0, defenseReduction: 0, isBackstab: false };
 

--- a/src/data/effects.js
+++ b/src/data/effects.js
@@ -319,5 +319,21 @@ export const EFFECTS = {
         duration: 300,
         tags: ['alphabet_state', 'J_state'],
         stats: { movement: -1 }
+    },
+
+    inspired_weapon: {
+        name: '열망 고양',
+        type: 'buff',
+        duration: 400,
+        stats: { attackPower: 1 },
+        tags: ['aspiration', 'buff', 'aspiration_effect']
+    },
+
+    despairing_weapon: {
+        name: '열망 절망',
+        type: 'debuff',
+        duration: 400,
+        stats: { attackPower: -1 },
+        tags: ['aspiration', 'debuff', 'aspiration_effect']
     }
 };

--- a/src/data/items.js
+++ b/src/data/items.js
@@ -5,6 +5,12 @@ export const ITEMS = {
         type: 'weapon',
         damageDice: '1d6',
         tags: ['melee', 'sword'],
+        aspiration: {
+            personality: 'standard',
+            current: 50,
+            max: 100,
+            state: 'stable',
+        },
         knockbackChance: 0.1,
         imageKey: 'sword',
         stats: { attackPower: 2 },
@@ -18,6 +24,12 @@ export const ITEMS = {
         type: 'weapon',
         damageDice: '1d6',
         tags: ['ranged', 'bow', 'finesse_weapon'],
+        aspiration: {
+            personality: 'focused',
+            current: 50,
+            max: 100,
+            state: 'stable',
+        },
         imageKey: 'bow',
         stats: { attackPower: 2, attackRange: 384 },
         tier: 'normal',
@@ -31,6 +43,12 @@ export const ITEMS = {
         type: 'weapon',
         damageDice: '1d6',
         tags: ['ranged', 'bow', 'finesse_weapon', 'song'],
+        aspiration: {
+            personality: 'artistic',
+            current: 50,
+            max: 100,
+            state: 'stable',
+        },
         imageKey: 'violin-bow',
         stats: { attackPower: 2, attackRange: 384 },
         tier: 'normal',
@@ -135,6 +153,12 @@ export const ITEMS = {
         type: 'weapon',
         damageDice: '1d6',
         tags: ['melee', 'sword'],
+        aspiration: {
+            personality: 'standard',
+            current: 50,
+            max: 100,
+            state: 'stable',
+        },
         knockbackChance: 0.15,
         imageKey: 'sword',
         stats: { attackPower: 2 },
@@ -151,6 +175,12 @@ export const ITEMS = {
         tags: ['melee', 'sword', 'finesse_weapon'],
         knockbackChance: 0.2,
         imageKey: 'sword',
+        aspiration: {
+            personality: 'noble',
+            current: 50,
+            max: 100,
+            state: 'stable',
+        },
         stats: {
             attackPower: 3,
             movement: 2,
@@ -165,36 +195,43 @@ export const ITEMS = {
     axe: {
         name: '도끼', type: 'weapon', damageDice: '1d10',
         tags: ['melee', 'axe'], imageKey: 'axe', stats: { attackPower: 5 },
+        aspiration: { personality: 'bloodthirsty', current: 50, max: 100, state: 'stable' },
         tier: 'normal', durability: 150, weight: 15, toughness: 4
     },
     mace: {
         name: '메이스', type: 'weapon', damageDice: '2d6',
         tags: ['melee', 'mace'], imageKey: 'mace', stats: { attackPower: 4 },
+        aspiration: { personality: 'stubborn', current: 50, max: 100, state: 'stable' },
         tier: 'normal', durability: 200, weight: 18, toughness: 6
     },
     staff: {
         name: '지팡이', type: 'weapon', damageDice: '1d4',
         tags: ['ranged', 'staff', 'magic_weapon'], imageKey: 'staff', stats: { intelligence: 3 },
+        aspiration: { personality: 'sage', current: 50, max: 100, state: 'stable' },
         tier: 'normal', durability: 70, weight: 5, toughness: 2
     },
     spear: {
         name: '창', type: 'weapon', damageDice: '1d8',
         tags: ['melee', 'spear', 'reach'], imageKey: 'spear', stats: { attackPower: 3, attackRange: 256 },
+        aspiration: { personality: 'loyal', current: 50, max: 100, state: 'stable' },
         tier: 'normal', durability: 100, weight: 9, toughness: 5
     },
     scythe: {
         name: '낫', type: 'weapon', damageDice: '1d12',
         tags: ['melee', 'scythe', 'reach'], imageKey: 'scythe', stats: { attackPower: 6, attackRange: 224 },
+        aspiration: { personality: 'grim', current: 50, max: 100, state: 'stable' },
         tier: 'rare', durability: 90, weight: 11, toughness: 3
     },
     whip: {
         name: '채찍', type: 'weapon', damageDice: '1d6',
         tags: ['ranged', 'whip', 'finesse_weapon'], imageKey: 'whip', stats: { agility: 2, attackRange: 288 },
+        aspiration: { personality: 'trickster', current: 50, max: 100, state: 'stable' },
         tier: 'normal', durability: 60, weight: 4, toughness: 1
     },
     dagger: {
         name: '단검', type: 'weapon', damageDice: '1d4',
         tags: ['melee', 'dagger', 'finesse_weapon'], imageKey: 'dagger', stats: { attackSpeed: 0.3 },
+        aspiration: { personality: 'craven', current: 50, max: 100, state: 'stable' },
         tier: 'normal', durability: 80, weight: 3, toughness: 2
     },
     // --- 여기까지 ---

--- a/src/entities.js
+++ b/src/entities.js
@@ -372,6 +372,15 @@ export class Item {
         if (this.image) {
             ctx.drawImage(this.image, this.x, this.y, this.width, this.height);
         }
+        if (this.aspiration) {
+            if (this.aspiration.state === 'inspired') {
+                ctx.fillStyle = 'rgba(255,0,0,0.4)';
+                ctx.fillRect(this.x, this.y, this.width, this.height);
+            } else if (this.aspiration.state === 'despairing') {
+                ctx.fillStyle = 'rgba(50,50,255,0.4)';
+                ctx.fillRect(this.x, this.y, this.width, this.height);
+            }
+        }
     }
 
     getSaveState() {

--- a/src/factory.js
+++ b/src/factory.js
@@ -249,6 +249,9 @@ export class ItemFactory {
         item.baseId = itemId;
         item.type = baseItem.type;
         item.tags = [...baseItem.tags];
+        if (baseItem.aspiration) {
+            item.aspiration = { ...baseItem.aspiration };
+        }
 
         if (baseItem.tier) item.tier = baseItem.tier;
         if (baseItem.durability) item.durability = baseItem.durability;

--- a/src/game.js
+++ b/src/game.js
@@ -973,6 +973,20 @@ export class Game {
             data.entity.stats.recalculate();
         });
 
+        eventManager.subscribe('aspiration_state_changed', (data) => {
+            const { weapon, newState } = data;
+            const wielder = this.findEntityByWeapon(weapon);
+            if (!wielder) return;
+            this.effectManager.removeEffectsByTag(wielder, 'aspiration_effect');
+            let effectId = null;
+            if (newState === 'inspired') effectId = 'inspired_weapon';
+            else if (newState === 'despairing') effectId = 'despairing_weapon';
+            if (effectId) {
+                this.effectManager.addEffect(wielder, effectId);
+                this.eventManager.publish('log', { message: `[열망] ${weapon.name} 상태가 ${newState} 상태가 되었습니다.`, color: 'magenta' });
+            }
+        });
+
         eventManager.subscribe('key_pressed', (data) => {
             const key = data.key;
             if (gameState.isPaused || gameState.isGameOver) return;
@@ -1100,6 +1114,17 @@ export class Game {
                 return;
             }
         });
+    }
+
+    findEntityByWeapon(weapon) {
+        if (this.gameState.player.equipment.weapon === weapon) return this.gameState.player;
+        for (const m of this.mercenaryManager.mercenaries) {
+            if (m.equipment.weapon === weapon) return m;
+        }
+        for (const m of this.monsterManager.monsters) {
+            if (m.equipment.weapon === weapon) return m;
+        }
+        return null;
     }
 
     findNearestEnemy(caster, enemies, range = Infinity) {

--- a/src/micro/AspirationEngine.js
+++ b/src/micro/AspirationEngine.js
@@ -1,0 +1,48 @@
+export class AspirationEngine {
+    constructor(eventManager) {
+        this.eventManager = eventManager;
+        this.init();
+        console.log('[AspirationEngine] Initialized.');
+    }
+
+    init() {
+        if (!this.eventManager) return;
+        this.eventManager.subscribe('entity_death', e => this.handleEvent('entity_death', e));
+        this.eventManager.subscribe('entity_damaged', e => this.handleEvent('entity_damaged', e));
+        this.eventManager.subscribe('attack_missed', e => this.handleEvent('attack_missed', e));
+    }
+
+    handleEvent(type, data) {
+        const weapon = data.attacker?.equipment?.weapon;
+        if (!weapon || !weapon.aspiration) return;
+
+        let change = 0;
+        if (type === 'entity_death') {
+            if (data.victim?.isFriendly === false) change = 10;
+        } else if (type === 'entity_damaged') {
+            if (data.defender?.id === data.attacker?.id) change = -5;
+        } else if (type === 'attack_missed') {
+            change = -3;
+        }
+
+        if (change !== 0) {
+            this.updateAspiration(weapon, change);
+        }
+    }
+
+    updateAspiration(weapon, change) {
+        const asp = weapon.aspiration;
+        asp.current = Math.max(0, Math.min(asp.max, asp.current + change));
+        const oldState = asp.state;
+        if (asp.current >= 80) {
+            asp.state = 'inspired';
+        } else if (asp.current <= 20) {
+            asp.state = 'despairing';
+        } else {
+            asp.state = 'stable';
+        }
+        if (oldState !== asp.state && this.eventManager) {
+            this.eventManager.publish('aspiration_state_changed', { weapon, newState: asp.state });
+        }
+    }
+}

--- a/src/micro/MicroEngine.js
+++ b/src/micro/MicroEngine.js
@@ -1,4 +1,5 @@
 import { MicroTurnManager } from './MicroTurnManager.js';
+import { AspirationEngine } from './AspirationEngine.js';
 
 // src/micro/MicroEngine.js
 
@@ -8,6 +9,7 @@ export class MicroEngine {
     constructor(eventManager) {
         this.eventManager = eventManager;
         this.turnManager = new MicroTurnManager();
+        this.aspirationEngine = new AspirationEngine(this.eventManager);
 
         if (this.eventManager) {
             this.eventManager.subscribe('attack_landed', data => this.handleAttackLanded(data));

--- a/tests/aspirationEngine.test.js
+++ b/tests/aspirationEngine.test.js
@@ -1,0 +1,22 @@
+import { describe, test, assert } from './helpers.js';
+import { EventManager } from '../src/managers/eventManager.js';
+import { AspirationEngine } from '../src/micro/AspirationEngine.js';
+
+describe('AspirationEngine', () => {
+  test('weapon aspiration increases and triggers state change', () => {
+    const eventManager = new EventManager();
+    const engine = new AspirationEngine(eventManager);
+    const weapon = { name: 'test sword', aspiration: { personality: 'std', current: 70, max: 100, state: 'stable' } };
+    const attacker = { equipment: { weapon } };
+    let triggered = false;
+    eventManager.subscribe('aspiration_state_changed', d => {
+      triggered = true;
+      assert.strictEqual(d.weapon, weapon);
+      assert.strictEqual(d.newState, 'inspired');
+    });
+    eventManager.publish('entity_death', { attacker, victim: { isFriendly: false } });
+    eventManager.publish('entity_death', { attacker, victim: { isFriendly: false } });
+    assert.strictEqual(weapon.aspiration.current, 90);
+    assert.ok(triggered);
+  });
+});


### PR DESCRIPTION
## Summary
- add aspiration property to weapon data
- implement AspirationEngine to track weapon states
- integrate new engine with MicroEngine and Game
- apply visual overlay to inspired or despairing weapons
- create inspired/despairing effects and hook into event flow
- add basic accuracy check that can publish attack_missed events
- test AspirationEngine behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6859688788fc8327aa698a999d13c99e