### PR TITLE
Add aspiration system

### DIFF
--- a/src/data/effects.js
+++ b/src/data/effects.js
@@ -319,5 +319,25 @@ export const EFFECTS = {
         duration: 300,
         tags: ['alphabet_state', 'J_state'],
         stats: { movement: -1 }
+    },
+
+    // '열망 시스템' 효과 추가
+    inspired_weapon: {
+        name: '고양된 무기',
+        duration: Infinity,
+        stats: {
+            damage_mult: 0.15,
+            attack_speed_mult: 0.1,
+        },
+        description: '무기의 열망이 최고조에 달해, 성능이 강화됩니다.'
+    },
+    despairing_weapon: {
+        name: '절망한 무기',
+        duration: Infinity,
+        stats: {
+            damage_mult: -0.15,
+            accuracy_add: -10,
+        },
+        description: '무기의 열망이 바닥나, 제 성능을 발휘하지 못합니다.'
     }
 };

--- a/src/data/items.js
+++ b/src/data/items.js
@@ -5,6 +5,12 @@ export const ITEMS = {
         type: 'weapon',
         damageDice: '1d6',
         tags: ['melee', 'sword'],
+        aspiration: {
+            personality: 'standard',
+            current: 50,
+            max: 100,
+            state: 'stable',
+        },
         knockbackChance: 0.1,
         imageKey: 'sword',
         stats: { attackPower: 2 },
@@ -18,6 +24,12 @@ export const ITEMS = {
         type: 'weapon',
         damageDice: '1d6',
         tags: ['ranged', 'bow', 'finesse_weapon'],
+        aspiration: {
+            personality: 'focused',
+            current: 50,
+            max: 100,
+            state: 'stable',
+        },
         imageKey: 'bow',
         stats: { attackPower: 2, attackRange: 384 },
         tier: 'normal',
@@ -31,6 +43,12 @@ export const ITEMS = {
         type: 'weapon',
         damageDice: '1d6',
         tags: ['ranged', 'bow', 'finesse_weapon', 'song'],
+        aspiration: {
+            personality: 'standard',
+            current: 50,
+            max: 100,
+            state: 'stable',
+        },
         imageKey: 'violin-bow',
         stats: { attackPower: 2, attackRange: 384 },
         tier: 'normal',
@@ -135,6 +153,12 @@ export const ITEMS = {
         type: 'weapon',
         damageDice: '1d6',
         tags: ['melee', 'sword'],
+        aspiration: {
+            personality: 'standard',
+            current: 50,
+            max: 100,
+            state: 'stable',
+        },
         knockbackChance: 0.15,
         imageKey: 'sword',
         stats: { attackPower: 2 },
@@ -149,6 +173,12 @@ export const ITEMS = {
         type: 'weapon',
         damageDice: '1d8',
         tags: ['melee', 'sword', 'finesse_weapon'],
+        aspiration: {
+            personality: 'standard',
+            current: 50,
+            max: 100,
+            state: 'stable',
+        },
         knockbackChance: 0.2,
         imageKey: 'sword',
         stats: {
@@ -164,37 +194,86 @@ export const ITEMS = {
     // --- 신규 무기 아이템 정의 ---
     axe: {
         name: '도끼', type: 'weapon', damageDice: '1d10',
-        tags: ['melee', 'axe'], imageKey: 'axe', stats: { attackPower: 5 },
+        tags: ['melee', 'axe'],
+        aspiration: {
+            personality: 'standard',
+            current: 50,
+            max: 100,
+            state: 'stable',
+        },
+        imageKey: 'axe', stats: { attackPower: 5 },
         tier: 'normal', durability: 150, weight: 15, toughness: 4
     },
     mace: {
         name: '메이스', type: 'weapon', damageDice: '2d6',
-        tags: ['melee', 'mace'], imageKey: 'mace', stats: { attackPower: 4 },
+        tags: ['melee', 'mace'],
+        aspiration: {
+            personality: 'standard',
+            current: 50,
+            max: 100,
+            state: 'stable',
+        },
+        imageKey: 'mace', stats: { attackPower: 4 },
         tier: 'normal', durability: 200, weight: 18, toughness: 6
     },
     staff: {
         name: '지팡이', type: 'weapon', damageDice: '1d4',
-        tags: ['ranged', 'staff', 'magic_weapon'], imageKey: 'staff', stats: { intelligence: 3 },
+        tags: ['ranged', 'staff', 'magic_weapon'],
+        aspiration: {
+            personality: 'standard',
+            current: 50,
+            max: 100,
+            state: 'stable',
+        },
+        imageKey: 'staff', stats: { intelligence: 3 },
         tier: 'normal', durability: 70, weight: 5, toughness: 2
     },
     spear: {
         name: '창', type: 'weapon', damageDice: '1d8',
-        tags: ['melee', 'spear', 'reach'], imageKey: 'spear', stats: { attackPower: 3, attackRange: 256 },
+        tags: ['melee', 'spear', 'reach'],
+        aspiration: {
+            personality: 'standard',
+            current: 50,
+            max: 100,
+            state: 'stable',
+        },
+        imageKey: 'spear', stats: { attackPower: 3, attackRange: 256 },
         tier: 'normal', durability: 100, weight: 9, toughness: 5
     },
     scythe: {
         name: '낫', type: 'weapon', damageDice: '1d12',
-        tags: ['melee', 'scythe', 'reach'], imageKey: 'scythe', stats: { attackPower: 6, attackRange: 224 },
+        tags: ['melee', 'scythe', 'reach'],
+        aspiration: {
+            personality: 'standard',
+            current: 50,
+            max: 100,
+            state: 'stable',
+        },
+        imageKey: 'scythe', stats: { attackPower: 6, attackRange: 224 },
         tier: 'rare', durability: 90, weight: 11, toughness: 3
     },
     whip: {
         name: '채찍', type: 'weapon', damageDice: '1d6',
-        tags: ['ranged', 'whip', 'finesse_weapon'], imageKey: 'whip', stats: { agility: 2, attackRange: 288 },
+        tags: ['ranged', 'whip', 'finesse_weapon'],
+        aspiration: {
+            personality: 'standard',
+            current: 50,
+            max: 100,
+            state: 'stable',
+        },
+        imageKey: 'whip', stats: { agility: 2, attackRange: 288 },
         tier: 'normal', durability: 60, weight: 4, toughness: 1
     },
     dagger: {
         name: '단검', type: 'weapon', damageDice: '1d4',
-        tags: ['melee', 'dagger', 'finesse_weapon'], imageKey: 'dagger', stats: { attackSpeed: 0.3 },
+        tags: ['melee', 'dagger', 'finesse_weapon'],
+        aspiration: {
+            personality: 'standard',
+            current: 50,
+            max: 100,
+            state: 'stable',
+        },
+        imageKey: 'dagger', stats: { attackSpeed: 0.3 },
         tier: 'normal', durability: 80, weight: 3, toughness: 2
     },
     // --- 여기까지 ---

--- a/src/game.js
+++ b/src/game.js
@@ -38,6 +38,8 @@ import { TankerGhostAI, RangedGhostAI, SupporterGhostAI, CCGhostAI } from './ai.
 import { EMBLEMS } from './data/emblems.js';
 import { adjustMonsterStatsForAquarium } from './utils/aquariumUtils.js';
 import DataRecorder from './managers/dataRecorder.js';
+import { AspirationManager } from './managers/aspirationManager.js';
+import { MicroWorldWorker } from './micro/MicroWorldWorker.js';
 import { CinematicManager } from './managers/cinematicManager.js';
 import { ItemTracker } from './managers/itemTracker.js';
 
@@ -167,6 +169,7 @@ export class Game {
         this.mercenaryManager.setTraitManager(this.traitManager);
         this.monsterManager.setTraitManager(this.traitManager);
         this.parasiteManager = this.managers.ParasiteManager;
+        this.microWorld = new MicroWorldWorker();
 
         // 매니저 간 의존성 연결
         this.equipmentManager.setTagManager(this.tagManager);
@@ -434,6 +437,14 @@ export class Game {
         }
         this.monsterManager.monsters.push(...monsters);
         this.monsterManager.monsters.forEach(m => this.monsterGroup.addMember(m));
+
+        this.entityManager = {
+            findEntityByWeaponId: (weaponId) => {
+                const list = [this.gameState.player, ...this.mercenaryManager.mercenaries, ...this.monsterManager.monsters, ...(this.petManager?.pets || [])];
+                return list.find(e => e.equipment?.weapon && e.equipment.weapon.id === weaponId) || null;
+            }
+        };
+        this.aspirationManager = new AspirationManager(this.eventManager, this.microWorld, this.effectManager, this.vfxManager, this.entityManager);
 
         // === 4. 용병 고용 로직 ===
         const hireBtn = document.getElementById('hire-mercenary');

--- a/src/managers/aspirationManager.js
+++ b/src/managers/aspirationManager.js
@@ -1,0 +1,74 @@
+export class AspirationManager {
+    constructor(eventManager, microWorld, effectManager, vfxManager, entityManager) {
+        this.eventManager = eventManager;
+        this.microWorld = microWorld;
+        this.effectManager = effectManager;
+        this.vfxManager = vfxManager;
+        this.entityManager = entityManager;
+
+        this.microWorld.postMessage({ type: 'init_module', module: 'AspirationEngine' });
+        this.setupEventListeners();
+    }
+
+    setupEventListeners() {
+        const eventsToForward = ['entity_death', 'entity_damaged', 'attack_missed'];
+        for (const eventType of eventsToForward) {
+            this.eventManager.subscribe(eventType, (data) => {
+                const payload = { type: eventType, data: this.sanitizeEventData(data) };
+                this.microWorld.postMessage({ type: 'macro_event', payload });
+            });
+        }
+
+        this.microWorld.subscribe('aspiration_state_changed_from_micro', (data) => {
+            this.applyAspirationState(data.weaponId, data.newState);
+        });
+    }
+
+    sanitizeEventData(data) {
+        const sanitized = {};
+        for (const key in data) {
+            const value = data[key];
+            if (typeof value === 'object' && value !== null && value.id) {
+                sanitized[key] = {
+                    id: value.id,
+                    isFriendly: value.isFriendly,
+                    isPlayer: value.isPlayer,
+                    equipment: value.equipment ? { weapon: value.equipment.weapon } : undefined,
+                };
+            } else {
+                sanitized[key] = value;
+            }
+        }
+        return sanitized;
+    }
+
+    applyAspirationState(weaponId, newState) {
+        const wielder = this.entityManager.findEntityByWeaponId(weaponId);
+        if (!wielder || !wielder.equipment.weapon) return;
+
+        const weapon = wielder.equipment.weapon;
+        this.effectManager.removeEffectBySource(wielder, `aspiration_${weapon.id}`);
+        this.vfxManager.removeWeaponAspirationEffect(wielder);
+
+        let effectId = null;
+        let logMessage = `[열망] ${wielder.name}의 ${weapon.name}이(가) 안정을 되찾았습니다.`;
+        let logColor = 'gray';
+
+        if (newState === 'inspired') {
+            effectId = 'inspired_weapon';
+            logMessage = `[열망] ${wielder.name}의 ${weapon.name}이(가) 고양되었습니다!`;
+            logColor = 'gold';
+        } else if (newState === 'despairing') {
+            effectId = 'despairing_weapon';
+            logMessage = `[열망] ${wielder.name}의 ${weapon.name}이(가) 절망에 빠졌습니다...`;
+            logColor = 'purple';
+        }
+
+        if (effectId) {
+            this.effectManager.addEffect(wielder, effectId, `aspiration_${weapon.id}`);
+        }
+        this.vfxManager.applyWeaponAspirationEffect(wielder, newState);
+
+        this.eventManager.publish('log', { message: logMessage, color: logColor });
+    }
+}

--- a/src/managers/effectManager.js
+++ b/src/managers/effectManager.js
@@ -98,6 +98,15 @@ export class EffectManager {
         }
     }
 
+    removeEffectBySource(target, source) {
+        if (!target.effects) return;
+        for (const effect of [...target.effects]) {
+            if (effect.caster === source) {
+                this.removeEffect(target, effect);
+            }
+        }
+    }
+
     update(entities) {
         entities.forEach(entity => {
             if (entity.effects.length === 0) return;

--- a/src/managers/vfx/ParticleEngine.js
+++ b/src/managers/vfx/ParticleEngine.js
@@ -38,6 +38,26 @@ export class ParticleEngine {
         return emitter;
     }
 
+    createEmitter(options = {}) {
+        const emitter = {
+            id: options.id || Math.random().toString(36).substr(2, 9),
+            x: options.target?.x || 0,
+            y: options.target?.y || 0,
+            spawnRate: 2,
+            duration: options.duration !== undefined ? options.duration : 60,
+            particleOptions: options.particleOptions || {},
+            followTarget: options.target || null,
+            offsetX: options.offset?.x || 0,
+            offsetY: options.offset?.y || 0,
+        };
+        this.emitters.push(emitter);
+        return emitter;
+    }
+
+    hasEmitter(id) {
+        return this.emitters.some(e => e.id === id);
+    }
+
     createTrail(target, options = {}) {
         return this.addEmitter(target.x, target.y, {
             followTarget: target,

--- a/src/managers/vfxManager.js
+++ b/src/managers/vfxManager.js
@@ -373,6 +373,36 @@ export class VFXManager {
         this.particleEngine.removeEmitter(emitter);
     }
 
+    // '열망 시스템' 시각 효과 적용 함수 추가
+    applyWeaponAspirationEffect(entity, state) {
+        this.removeWeaponAspirationEffect(entity);
+        if (state === 'stable') return;
+
+        const color = state === 'inspired' ? 0xff0000 : 0x800080;
+        const effectId = `aspiration_vfx_${entity.id}`;
+
+        this.particleEngine.createEmitter({
+            id: effectId,
+            target: entity,
+            offset: { x: 0, y: -entity.tileSize / 2 },
+            particleOptions: {
+                colors: [color],
+                size: [2, 4],
+                lifetime: [0.3, 0.6],
+                speed: [10, 20],
+                count: state === 'inspired' ? 20 : 5,
+            },
+            duration: Infinity,
+        });
+    }
+
+    removeWeaponAspirationEffect(entity) {
+        const effectId = `aspiration_vfx_${entity.id}`;
+        if (this.particleEngine.hasEmitter(effectId)) {
+            this.particleEngine.removeEmitter(effectId);
+        }
+    }
+
     /**
      * 이미지 스프라이트 이펙트를 추가합니다.
      * 대상 위치에 밝게 표시되며 일정 시간 후 사라집니다.

--- a/src/micro/AspirationEngine.js
+++ b/src/micro/AspirationEngine.js
@@ -1,0 +1,58 @@
+export class AspirationEngine {
+    constructor(microEventManager) {
+        this.eventManager = microEventManager;
+        // 거시세계(메인 게임)의 이벤트를 수신하여 정신력 변화를 처리
+        this.eventManager.subscribe('macro_event_forwarded', this.handleMacroEvent.bind(this));
+    }
+
+    handleMacroEvent(event) {
+        const { type, data } = event;
+        const weapon = data.attacker?.equipment?.weapon;
+        if (!weapon || !weapon.aspiration) return;
+
+        let change = 0;
+        const asp = weapon.aspiration;
+        const personality = asp.personality;
+
+        switch (type) {
+            case 'entity_death':
+                if (data.victim?.isFriendly === false) {
+                    change = (personality === 'bloodthirsty') ? 15 : 10;
+                }
+                break;
+            case 'entity_damaged':
+                if (data.isPlayer) {
+                    change = (personality === 'craven') ? -8 : -5;
+                }
+                break;
+            case 'attack_missed':
+                change = -3;
+                break;
+        }
+
+        if (change !== 0) {
+            this.updateAspiration(weapon, change);
+        }
+    }
+
+    updateAspiration(weapon, change) {
+        const asp = weapon.aspiration;
+        asp.current = Math.max(0, Math.min(asp.max, asp.current + change));
+
+        const oldState = asp.state;
+        if (asp.current >= 85) {
+            asp.state = 'inspired';
+        } else if (asp.current <= 15) {
+            asp.state = 'despairing';
+        } else {
+            asp.state = 'stable';
+        }
+
+        if (oldState !== asp.state) {
+            this.eventManager.publish('aspiration_state_changed_from_micro', {
+                weaponId: weapon.id,
+                newState: asp.state
+            });
+        }
+    }
+}

--- a/src/micro/MicroWorldWorker.js
+++ b/src/micro/MicroWorldWorker.js
@@ -1,9 +1,15 @@
 import { Worker } from 'node:worker_threads';
+import { EventEmitter } from 'events';
 
-export class MicroWorldWorker {
+export class MicroWorldWorker extends EventEmitter {
     constructor() {
+        super();
         const url = new URL('./microWorldWorkerThread.js', import.meta.url);
         this.worker = new Worker(url, { type: 'module' });
+        this.worker.on('message', msg => {
+            if (msg.type === 'resolveAttackComplete' || msg.type === 'updateComplete') return;
+            this.emit(msg.type, msg.payload);
+        });
     }
 
     resolveAttack(attacker, defender) {
@@ -30,6 +36,14 @@ export class MicroWorldWorker {
             this.worker.on('message', listener);
             this.worker.postMessage({ type: 'update', items });
         });
+    }
+
+    postMessage(data) {
+        this.worker.postMessage(data);
+    }
+
+    subscribe(event, handler) {
+        this.on(event, handler);
     }
 
     terminate() {

--- a/src/micro/microWorldWorkerThread.js
+++ b/src/micro/microWorldWorkerThread.js
@@ -1,12 +1,29 @@
 import { parentPort } from 'node:worker_threads';
 import { MicroCombatManager } from './MicroCombatManager.js';
 import { MicroTurnManager } from './MicroTurnManager.js';
+import { EventManager } from '../managers/eventManager.js';
+import { AspirationEngine } from './AspirationEngine.js';
 
-const combatManager = new MicroCombatManager({ publish: () => {} });
+const microEventManager = new EventManager();
+const combatManager = new MicroCombatManager(microEventManager);
 const turnManager = new MicroTurnManager();
+let aspirationEngine = null;
+
+microEventManager.subscribe('aspiration_state_changed_from_micro', (data) => {
+    parentPort.postMessage({ type: 'aspiration_state_changed_from_micro', payload: data });
+});
 
 parentPort.on('message', msg => {
-    switch (msg.type) {
+    const { type, payload, module } = msg;
+    switch (type) {
+        case 'init_module':
+            if (module === 'AspirationEngine' && !aspirationEngine) {
+                aspirationEngine = new AspirationEngine(microEventManager);
+            }
+            break;
+        case 'macro_event':
+            microEventManager.publish('macro_event_forwarded', payload);
+            break;
         case 'resolveAttack':
             combatManager.resolveAttack(msg.attacker, msg.defender);
             parentPort.postMessage({ type: 'resolveAttackComplete', attacker: msg.attacker, defender: msg.defender });


### PR DESCRIPTION
## Summary
- implement aspiration data for weapons
- add aspiration engine in micro world
- implement manager to sync aspiration states
- expand visual effects with aspiration particle support
- support aspiration events in worker

## Testing
- `npm test` *(fails: Command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6859f6e5dbac832790b4bc9337cfa65c