### PR TITLE
Fix DataCloneError on event forwarding

### DIFF
--- a/src/managers/aspirationManager.js
+++ b/src/managers/aspirationManager.js
@@ -33,13 +33,27 @@ export class AspirationManager {
                     id: value.id,
                     isFriendly: value.isFriendly,
                     isPlayer: value.isPlayer,
-                    equipment: value.equipment ? { weapon: value.equipment.weapon } : undefined,
+                    equipment: value.equipment ? { weapon: this.sanitizeItemData(value.equipment.weapon) } : undefined,
                 };
             } else {
                 sanitized[key] = value;
             }
         }
         return sanitized;
+    }
+
+    sanitizeItemData(item) {
+        if (!item) return undefined;
+        return {
+            id: item.id,
+            baseId: item.baseId,
+            type: item.type,
+            tier: item.tier,
+            weight: item.weight,
+            toughness: item.toughness,
+            durability: item.durability,
+            aspiration: item.aspiration ? { ...item.aspiration } : undefined,
+        };
     }
 
     applyAspirationState(weaponId, newState) {


### PR DESCRIPTION
## Summary
- sanitize weapon data before forwarding events to worker

## Testing
- `npm test` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685a01c9316c8327acfb6ee50031b81d