### PR TITLE
Add auto BGM loop

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,8 +2,18 @@
 import { Game } from './src/game.js';
 import { registerServiceWorker } from './src/utils/swRegister.js';
 
+let game = null;
+
+function initializeAudio() {
+    if (game) {
+        game.startBGM();
+    }
+}
+
 window.onload = () => {
     registerServiceWorker();
-    const game = new Game();
+    game = new Game();
     game.start();
+    document.addEventListener('keydown', initializeAudio, { once: true });
+    document.addEventListener('click', initializeAudio, { once: true });
 };

--- a/src/game.js
+++ b/src/game.js
@@ -156,6 +156,7 @@ export class Game {
         this.vfxManager = this.managers.VFXManager;
         this.vfxManager.game = this;
         this.soundManager = this.managers.SoundManager;
+        this.bgmManager = this.managers.BgmManager;
         this.effectManager = this.managers.EffectManager;
         this.auraManager = new Managers.AuraManager(this.effectManager, this.eventManager, this.vfxManager);
         this.microItemAIManager = new Managers.MicroItemAIManager();
@@ -1398,6 +1399,12 @@ export class Game {
             this.gameState.statPoints--;
             this.gameState.player.stats.allocatePoint(stat);
             this.gameState.player.stats.recalculate();
+        }
+    }
+
+    startBGM() {
+        if (this.bgmManager && !this.bgmManager.isInitialized) {
+            this.bgmManager.start();
         }
     }
 }

--- a/src/managers/bgmManager.js
+++ b/src/managers/bgmManager.js
@@ -1,0 +1,44 @@
+export class BgmManager {
+    constructor(eventManager = null, assets = null) {
+        this.eventManager = eventManager;
+        this.tracks = [];
+        this.currentIndex = 0;
+        this.audio = null;
+        this.isInitialized = false;
+
+        if (typeof window !== 'undefined') {
+            this._discoverTracks();
+        }
+    }
+
+    _discoverTracks() {
+        // Predefine track names for now. Future tracks should follow 'bgm_X.mp3'
+        const trackNames = ['bgm_1'];
+        this.tracks = trackNames.map(name => `assets/bgm/${name}.mp3`);
+    }
+
+    start() {
+        if (typeof window === 'undefined' || !this.tracks.length) return;
+
+        if (!this.audio) {
+            this.audio = new Audio();
+            this.audio.volume = 0.5;
+            this.audio.addEventListener('ended', () => this.next());
+        }
+        this.playCurrent();
+        this.isInitialized = true;
+    }
+
+    playCurrent() {
+        if (!this.audio) return;
+        this.audio.src = this.tracks[this.currentIndex];
+        this.audio.currentTime = 0;
+        this.audio.play().catch(() => {});
+    }
+
+    next() {
+        if (!this.tracks.length) return;
+        this.currentIndex = (this.currentIndex + 1) % this.tracks.length;
+        this.playCurrent();
+    }
+}

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -9,6 +9,7 @@ import { UIManager } from './uiManager.js';
 import { VFXManager } from './vfxManager.js';
 import { SkillManager } from './skillManager.js';
 import { SoundManager } from './soundManager.js';
+import { BgmManager } from './bgmManager.js';
 import { EffectManager } from './effectManager.js';
 import { ProjectileManager } from './projectileManager.js';
 import { ItemAIManager } from './item-ai-manager.js';
@@ -46,6 +47,7 @@ export {
     VFXManager,
     SkillManager,
     SoundManager,
+    BgmManager,
     EffectManager,
     ProjectileManager,
     ItemAIManager,


### PR DESCRIPTION
## Summary
- initialize background music on first user input
- loop through future tracks via new `BgmManager`
- wire up `BgmManager` to `Game`

## Testing
- `npm test` *(fails: Command terminated after starting but before completion)*

------
https://chatgpt.com/codex/tasks/task_e_685a19edcb20832783b2b9508db30e55