### PR TITLE
Add MistakeEngine with configurable toggle

### DIFF
--- a/config/gameSettings.js
+++ b/config/gameSettings.js
@@ -3,6 +3,8 @@ export const SETTINGS = {
     DEFAULT_ZOOM: 0.5,
     // 포그 오브 워 표시 여부를 제어합니다.
     ENABLE_FOG_OF_WAR: true,
+    // AI의 인간적인 실수 허용 여부를 제어합니다.
+    ENABLE_MISTAKE_ENGINE: false,
     // 이동 속도는 StatManager의 'movement' 스탯으로부터 파생됩니다.
     // ... 나중에 더 많은 설정 추가
 };

--- a/src/managers/ai/MistakeEngine.js
+++ b/src/managers/ai/MistakeEngine.js
@@ -1,0 +1,81 @@
+export class MistakeEngine {
+    static getFinalAction(entity, optimalAction, context) {
+        const enabled = context?.settings?.ENABLE_MISTAKE_ENGINE !== false;
+        if (!enabled) return optimalAction;
+        const chance = entity.properties?.mistakeChance ?? 0;
+        if (chance <= 0) return optimalAction;
+        if (Math.random() >= chance) return optimalAction;
+        console.log(`[MistakeEngine] ${entity.name} makes a mistake`);
+        const types = ['bad_target','bad_position','waste_action'];
+        const mistakeType = types[Math.floor(Math.random() * types.length)];
+        let mistake = null;
+        switch (mistakeType) {
+            case 'bad_target':
+                mistake = this.generateBadTargetAction(entity, optimalAction, context);
+                break;
+            case 'bad_position':
+                mistake = this.generateBadPositionAction(entity, optimalAction, context);
+                break;
+            case 'waste_action':
+                mistake = this.generateWasteAction(entity, optimalAction, context);
+                break;
+        }
+        return mistake || optimalAction;
+    }
+
+    static generateBadTargetAction(entity, optimalAction, context) {
+        const enemies = context.enemies || context.monsterManager?.monsters || [];
+        const allies = context.allies || context.mercenaryManager?.mercenaries || [];
+        if (entity.equipment?.weapon?.type === 'whip' && optimalAction.skill?.effect === 'pull') {
+            let strongest = null;
+            for (const e of enemies) {
+                if (!strongest || (e.attackPower || 0) > (strongest.attackPower || 0)) {
+                    strongest = e;
+                }
+            }
+            if (strongest) return { ...optimalAction, target: strongest };
+        }
+        if (entity.equipment?.weapon?.type === 'bow' && optimalAction.skill?.effect === 'knockback') {
+            const healer = allies.find(a => a.jobId === 'healer');
+            if (healer) {
+                const farEnemies = enemies.filter(e => Math.hypot(e.x - healer.x, e.y - healer.y) > 5);
+                if (farEnemies.length) {
+                    const rand = farEnemies[Math.floor(Math.random() * farEnemies.length)];
+                    return { ...optimalAction, target: rand };
+                }
+            }
+        }
+        return null;
+    }
+
+    static generateBadPositionAction(entity, optimalAction, context) {
+        if (optimalAction.type !== 'move' || !context.allies) return null;
+        const allies = context.allies.filter(a => a.id !== entity.id);
+        if (allies.length === 0) return null;
+        const avgX = allies.reduce((sum,a)=>sum+a.x,0)/allies.length;
+        const avgY = allies.reduce((sum,a)=>sum+a.y,0)/allies.length;
+        const vectorX = entity.x - avgX;
+        const vectorY = entity.y - avgY;
+        const targetX = entity.x + vectorX * 5;
+        const targetY = entity.y + vectorY * 5;
+        return { type: 'move', target: { x: targetX, y: targetY } };
+    }
+
+    static generateWasteAction(entity, optimalAction, context) {
+        if (optimalAction.type === 'skill' && optimalAction.skill?.effect === 'heal') {
+            const allies = context.allies || [];
+            const fullHpAlly = allies.find(a => a.hp >= a.maxHp);
+            if (fullHpAlly) return { ...optimalAction, target: fullHpAlly };
+        }
+        return null;
+    }
+}
+
+if (!Array.prototype.getRandom) {
+    Object.defineProperty(Array.prototype, 'getRandom', {
+        value: function() {
+            return this[Math.floor(Math.random() * this.length)];
+        },
+        enumerable: false
+    });
+}

--- a/src/managers/metaAIManager.js
+++ b/src/managers/metaAIManager.js
@@ -1,5 +1,7 @@
 import { MetaAIManager as BaseMetaAI } from './ai-managers.js';
 import { FearAI, ConfusionAI, BerserkAI, CharmAI } from '../ai.js';
+import { MistakeEngine } from './ai/MistakeEngine.js';
+import { SETTINGS } from '../../config/gameSettings.js';
 
 export class MetaAIManager extends BaseMetaAI {
     executeAction(entity, action, context) {
@@ -46,7 +48,7 @@ export class MetaAIManager extends BaseMetaAI {
     }
 
     update(context) {
-        const currentContext = { ...context, metaAIManager: this };
+        const currentContext = { ...context, metaAIManager: this, settings: SETTINGS };
         for (const groupId in this.groups) {
             const group = this.groups[groupId];
             const membersSorted = [...group.members].sort((a,b)=>(b.attackSpeed||1)-(a.attackSpeed||1));
@@ -84,7 +86,8 @@ export class MetaAIManager extends BaseMetaAI {
 
                 if (member.ai) {
                     const action = member.ai.decideAction(member, currentContext);
-                    this.executeAction(member, action, currentContext);
+                    const finalAction = MistakeEngine.getFinalAction(member, action, currentContext);
+                    this.executeAction(member, finalAction, currentContext);
                 }
             }
         }

--- a/tests/embargo.test.js
+++ b/tests/embargo.test.js
@@ -11,8 +11,10 @@ import { MeleeAI, PurifierAI, HealerAI, CompositeAI } from '../src/ai.js';
 import { Item } from '../src/entities.js';
 import { SKILLS } from '../src/data/skills.js';
 import { describe, test, assert } from './helpers.js';
+import { SETTINGS } from '../config/gameSettings.js';
 // TensorFlow is not needed in the test environment
 const tf = {};
+SETTINGS.ENABLE_MISTAKE_ENGINE = false;
 
 // 업데이트된 엠바고 테스트
 

--- a/tests/healerHeal.test.js
+++ b/tests/healerHeal.test.js
@@ -1,9 +1,11 @@
 import { HealerAI } from '../src/ai.js';
 import { CharacterFactory } from '../src/factory.js';
 import { SKILLS } from '../src/data/skills.js';
+import { SETTINGS } from '../config/gameSettings.js';
 import { describe, test, assert } from './helpers.js';
 
 const assets = { player:{}, mercenary:{} };
+SETTINGS.ENABLE_MISTAKE_ENGINE = false;
 
 describe('Healing', () => {
   test('healer skill restores ally hp', () => {

--- a/tests/purify.test.js
+++ b/tests/purify.test.js
@@ -2,8 +2,10 @@ import { PurifierAI, HealerAI, CompositeAI } from '../src/ai.js';
 import { CharacterFactory } from '../src/factory.js';
 import { SKILLS } from '../src/data/skills.js';
 import { describe, test, assert } from './helpers.js';
+import { SETTINGS } from '../config/gameSettings.js';
 
 const assets = { player:{}, mercenary:{} };
+SETTINGS.ENABLE_MISTAKE_ENGINE = false;
 
 describe('Purify', () => {
   test('healer removes ailment from ally', () => {


### PR DESCRIPTION
## Summary
- implement `MistakeEngine` for optional human-like AI mistakes
- expose `ENABLE_MISTAKE_ENGINE` setting in `config/gameSettings.js`
- integrate mistake engine into `MetaAIManager` and the extended manager
- disable mistake engine in several deterministic tests

## Testing
- `GROUP=Healing npm test` *(fails: npm execution halted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_685a35ba4da08327a59d72d274381d22