### PR TITLE
Implement basic reputation tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,7 @@
                     <h3>스킬</h3>
                     <div id="merc-skills" class="skill-list"></div>
                 </div>
+                <div id="reputation-history-panel"></div>
             </div>
         </div>
     </div>

--- a/src/game.js
+++ b/src/game.js
@@ -163,6 +163,7 @@ export class Game {
         this.microEngine = new MicroEngine(this.eventManager);
         this.microCombatManager = new MicroCombatManager(this.eventManager);
         this.synergyManager = new Managers.SynergyManager(this.eventManager);
+        this.reputationManager = new Managers.ReputationManager(this.eventManager, this.mercenaryManager);
         this.speechBubbleManager = this.managers.SpeechBubbleManager;
         this.equipmentRenderManager = this.managers.EquipmentRenderManager;
         this.mercenaryManager.equipmentRenderManager = this.equipmentRenderManager;

--- a/src/managers/ReputationManager.js
+++ b/src/managers/ReputationManager.js
@@ -1,0 +1,48 @@
+import { memoryDB } from '../persistence/MemoryDB.js';
+import { ScenarioEngine } from './ai/ScenarioEngine.js';
+
+export class ReputationManager {
+    constructor(eventManager, mercenaryManager) {
+        this.eventManager = eventManager;
+        this.mercenaryManager = mercenaryManager;
+        eventManager.subscribe('action_performed', (data) => this._onAction(data));
+    }
+
+    async _onAction({ entity, action, context }) {
+        if (!entity.isFriendly || entity.isPlayer) return;
+
+        const label = ScenarioEngine.getLabelForScenario(entity, action, context);
+        let change = 0;
+        let desc = '';
+        if (label) {
+            change = 1;
+            desc = `${action.type} 행동으로 훌륭한 판단(${label})을 보였습니다.`;
+        } else if (action.isMistake) {
+            change = -1;
+            desc = action.mistakeDescription || '실수를 저질렀습니다.';
+        } else {
+            return;
+        }
+
+        const allies = this.mercenaryManager.mercenaries.filter(m => m.id !== entity.id && !m.isDead);
+        for (const ally of allies) {
+            memoryDB.addEvent({
+                actorId: entity.id,
+                actorName: entity.name,
+                observerId: ally.id,
+                description: desc,
+                reputationChange: change,
+                timestamp: new Date().toISOString()
+            });
+        }
+
+        this.eventManager.publish('log', {
+            message: `${entity.name}의 평판이 ${change > 0 ? '올라갔습니다' : '나빠졌습니다'}.`,
+            color: change > 0 ? 'lightgreen' : 'salmon'
+        });
+    }
+
+    async getHistory(actorId) {
+        return memoryDB.getEventsFor(actorId);
+    }
+}

--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -208,6 +208,7 @@ export class MetaAIManager {
                 }
                 break;
         }
+        eventManager.publish('action_performed', { entity, action, context });
     }
 
     update(context) {

--- a/src/managers/ai/MistakeEngine.js
+++ b/src/managers/ai/MistakeEngine.js
@@ -20,7 +20,12 @@ export class MistakeEngine {
                 mistake = this.generateWasteAction(entity, optimalAction, context);
                 break;
         }
-        return mistake || optimalAction;
+        if (mistake) {
+            mistake.isMistake = true;
+            mistake.mistakeDescription = this.getMistakeDescription(mistake);
+            return mistake;
+        }
+        return optimalAction;
     }
 
     static generateBadTargetAction(entity, optimalAction, context) {
@@ -68,6 +73,12 @@ export class MistakeEngine {
             if (fullHpAlly) return { ...optimalAction, target: fullHpAlly };
         }
         return null;
+    }
+
+    static getMistakeDescription(action) {
+        if (action.type === 'move') return '진형을 이탈하여 혼자 움직였습니다.';
+        if (action.type === 'skill' && action.skill?.effect === 'heal') return '엉뚱한 대상에게 치유를 사용했습니다.';
+        return '이해할 수 없는 행동으로 실수를 저질렀습니다.';
     }
 }
 

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -28,6 +28,7 @@ import { SpeechBubbleManager } from './speechBubbleManager.js';
 import { AuraManager } from './AuraManager.js';
 import { PossessionAIManager } from './possessionAIManager.js';
 import { CombatDecisionEngine } from './ai/CombatDecisionEngine.js';
+import { ReputationManager } from './ReputationManager.js';
 // DataRecorder is only needed in a Node.js environment so we lazy-load it
 let DataRecorder = null;
 if (typeof process !== 'undefined' && process.versions?.node) {
@@ -65,6 +66,7 @@ export {
     AuraManager,
     SynergyManager,
     SpeechBubbleManager,
+    ReputationManager,
     CombatDecisionEngine,
     DataRecorder,
 };

--- a/src/managers/metaAIManager.js
+++ b/src/managers/metaAIManager.js
@@ -45,6 +45,7 @@ export class MetaAIManager extends BaseMetaAI {
                 super.executeAction(entity, action, context);
                 break;
         }
+        context.eventManager?.publish('action_performed', { entity, action, context });
     }
 
     update(context) {

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -4,6 +4,7 @@ import { FAITHS } from '../data/faiths.js';
 import { TRAITS } from '../data/traits.js';
 import { SYNERGIES } from '../data/synergies.js';
 import { ARTIFACTS } from '../data/artifacts.js';
+import { memoryDB } from '../persistence/MemoryDB.js';
 
 export class UIManager {
     constructor() {
@@ -30,6 +31,7 @@ export class UIManager {
         this.mercInventory = document.getElementById('merc-inventory');
         this.mercEquipment = document.getElementById('merc-equipment');
         this.mercSkills = document.getElementById('merc-skills');
+        this.reputationHistoryPanel = document.getElementById('reputation-history-panel');
         this.closeMercDetailBtn = document.getElementById('close-merc-detail-btn');
         this.mercenaryPanel = document.getElementById('mercenary-panel');
         this.mercenaryList = document.getElementById('mercenary-list');
@@ -140,7 +142,7 @@ export class UIManager {
         this.init(cb);
     }
 
-    showMercenaryDetail(mercenary) {
+    async showMercenaryDetail(mercenary) {
         if (!this.mercDetailPanel) return;
 
         this.mercDetailName.textContent = `${mercenary.constructor.name} (Lv.${mercenary.stats.get('level')})`;
@@ -283,6 +285,17 @@ export class UIManager {
                 div.style.backgroundSize = 'cover';
                 this._attachTooltip(div, `<strong>${skill.name}</strong><br>${skill.description}`);
                 this.mercSkills.appendChild(div);
+            });
+        }
+
+        if (this.reputationHistoryPanel) {
+            this.reputationHistoryPanel.innerHTML = '';
+            const history = await memoryDB.getEventsFor(mercenary.id);
+            history.forEach(ev => {
+                const div = document.createElement('div');
+                div.textContent = `[${new Date(ev.timestamp).toLocaleTimeString()}] ${ev.description}`;
+                div.style.color = ev.reputationChange > 0 ? 'green' : 'red';
+                this.reputationHistoryPanel.appendChild(div);
             });
         }
 

--- a/src/persistence/MemoryDB.js
+++ b/src/persistence/MemoryDB.js
@@ -1,0 +1,59 @@
+const DB_NAME = 'UnitMemories';
+const STORE_NAME = 'ReputationEvents';
+const DB_VERSION = 1;
+
+class MemoryDB {
+    constructor() {
+        this.db = null;
+    }
+
+    async open() {
+        if (typeof indexedDB === 'undefined') {
+            return null;
+        }
+        if (this.db) return this.db;
+        return new Promise((resolve, reject) => {
+            const request = indexedDB.open(DB_NAME, DB_VERSION);
+            request.onupgradeneeded = (event) => {
+                const db = event.target.result;
+                if (!db.objectStoreNames.contains(STORE_NAME)) {
+                    const store = db.createObjectStore(STORE_NAME, { keyPath: 'id', autoIncrement: true });
+                    store.createIndex('actorIdIndex', 'actorId', { unique: false });
+                }
+            };
+            request.onsuccess = () => {
+                this.db = request.result;
+                resolve(this.db);
+            };
+            request.onerror = () => reject(request.error);
+        });
+    }
+
+    async addEvent(data) {
+        const db = await this.open();
+        if (!db) return;
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction(STORE_NAME, 'readwrite');
+            const store = tx.objectStore(STORE_NAME);
+            const req = store.add(data);
+            req.onsuccess = () => resolve(req.result);
+            req.onerror = () => reject(req.error);
+        });
+    }
+
+    async getEventsFor(actorId) {
+        const db = await this.open();
+        if (!db) return [];
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction(STORE_NAME, 'readonly');
+            const store = tx.objectStore(STORE_NAME);
+            const index = store.index('actorIdIndex');
+            const req = index.getAll(actorId);
+            req.onsuccess = () => resolve(req.result || []);
+            req.onerror = () => reject(req.error);
+        });
+    }
+}
+
+export const memoryDB = new MemoryDB();
+export default memoryDB;

--- a/style.css
+++ b/style.css
@@ -362,6 +362,12 @@ body, html {
 .sheet-container { display: flex; gap: 15px; }
 .sheet-left { flex-basis: 300px; flex-shrink: 0; }
 .sheet-right { flex-grow: 1; }
+#reputation-history-panel {
+    margin-top: 10px;
+    max-height: 120px;
+    overflow-y: auto;
+    font-size: 12px;
+}
 
 #equipment-target-panel {
     z-index: 250;


### PR DESCRIPTION
## Summary
- store reputation events in IndexedDB via new `MemoryDB`
- track mercenary actions with `ReputationManager`
- mark actions from `MistakeEngine` so they can affect reputation
- publish `action_performed` events from AI managers
- display reputation history in mercenary detail UI

## Testing
- `npm test` *(fails: process hung and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_685a3b11d8008327a76d8573907cd5c4