### PR TITLE
Fix aspiration color not visible

### DIFF
--- a/src/managers/equipmentRenderManager.js
+++ b/src/managers/equipmentRenderManager.js
@@ -18,6 +18,14 @@ export class EquipmentRenderManager {
         const drawY = entity.height * -1;
 
         ctx.drawImage(weapon.image, drawX, drawY, drawWidth, drawHeight);
+
+        if (weapon.aspiration && weapon.aspiration.state && weapon.aspiration.state !== 'stable') {
+            const color = weapon.aspiration.state === 'inspired' ? 'gold' : 'purple';
+            ctx.globalCompositeOperation = 'source-atop';
+            ctx.fillStyle = color;
+            ctx.fillRect(drawX, drawY, drawWidth, drawHeight);
+            ctx.globalCompositeOperation = 'source-over';
+        }
     }
 
     drawShield(ctx, entity) {


### PR DESCRIPTION
## Summary
- overlay weapon with gold/purple when aspiration state changes

## Testing
- `node run-tests.mjs` *(fails: only partial output)*

------
https://chatgpt.com/codex/tasks/task_e_685a4d555a848327adea87767035dffc