### PR TITLE
Add GuidelineLoader module

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ await recorder.init();
 
 기본 포맷은 JSONL이며 `training.jsonl` 파일에 누적 기록됩니다.
 
+## Guideline Loader
+게임 시작 시 `GuidelineLoader`가 지정한 GitHub 경로에서 Markdown 가이드를 읽어
+JSON 형식으로 변환합니다. 설정 파일 `config/gameSettings.js`의 `GUIDELINE_REPO_URL`
+값을 `user/repo/contents/guidelines?ref=main` 형태로 지정하면 활성화됩니다. 게임을
+다시 시작하면 최신 가이드가 자동으로 로드됩니다.
+
 
 ## 결함 주입 테스트
 MBTI AI와 힐러 AI의 오류 처리 능력을 확인하는 시나리오가 `tests/faultInjection.test.js`에 있습니다. 버퍼/디버퍼 AI가 추가되면 동일한 파일에서 함께 관리합니다.

--- a/config/gameSettings.js
+++ b/config/gameSettings.js
@@ -5,6 +5,9 @@ export const SETTINGS = {
     ENABLE_FOG_OF_WAR: true,
     // AI의 인간적인 실수 허용 여부를 제어합니다.
     ENABLE_MISTAKE_ENGINE: false,
+    // guideline markdown files will be loaded from this GitHub API path
+    // example: 'user/repo/contents/guidelines?ref=main'
+    GUIDELINE_REPO_URL: '',
     // 이동 속도는 StatManager의 'movement' 스탯으로부터 파생됩니다.
     // ... 나중에 더 많은 설정 추가
 };

--- a/src/game.js
+++ b/src/game.js
@@ -38,6 +38,7 @@ import { TankerGhostAI, RangedGhostAI, SupporterGhostAI, CCGhostAI } from './ai.
 import { EMBLEMS } from './data/emblems.js';
 import { adjustMonsterStatsForAquarium } from './utils/aquariumUtils.js';
 import DataRecorder from './managers/dataRecorder.js';
+import GuidelineLoader from './managers/guidelineLoader.js';
 import { AspirationManager } from './managers/aspirationManager.js';
 import { MicroWorldWorker } from './micro/MicroWorldWorker.js';
 import { CinematicManager } from './managers/cinematicManager.js';
@@ -207,6 +208,8 @@ export class Game {
         this.cinematicManager = new CinematicManager(this);
         this.dataRecorder = new DataRecorder(this);
         this.dataRecorder.init();
+        this.guidelineLoader = new GuidelineLoader(SETTINGS.GUIDELINE_REPO_URL);
+        this.guidelineLoader.load();
         this.possessionAIManager = new PossessionAIManager(this.eventManager);
         this.itemFactory.emblems = EMBLEMS;
 

--- a/src/managers/guidelineLoader.js
+++ b/src/managers/guidelineLoader.js
@@ -1,0 +1,68 @@
+// src/managers/guidelineLoader.js
+import { SETTINGS } from '../../config/gameSettings.js';
+
+export default class GuidelineLoader {
+    constructor(url = SETTINGS.GUIDELINE_REPO_URL) {
+        this.url = url;
+        this.guidelines = {};
+    }
+
+    async fetchMarkdownList() {
+        if (!this.url) {
+            console.warn('[GuidelineLoader] No GUIDELINE_REPO_URL configured');
+            return [];
+        }
+        const apiUrl = `https://api.github.com/repos/${this.url}`;
+        const res = await fetch(apiUrl);
+        if (!res.ok) {
+            console.warn('[GuidelineLoader] Failed to fetch list:', res.status);
+            return [];
+        }
+        const files = await res.json();
+        return files.filter(f => f.name && f.name.endsWith('.md'));
+    }
+
+    async load() {
+        const list = await this.fetchMarkdownList();
+        const guidelines = {};
+        for (const file of list) {
+            try {
+                const res = await fetch(file.download_url);
+                if (!res.ok) {
+                    console.warn('[GuidelineLoader] Failed to fetch', file.name);
+                    continue;
+                }
+                const text = await res.text();
+                const key = file.name.replace(/\.md$/, '');
+                guidelines[key] = this.parseMarkdown(text);
+            } catch (e) {
+                console.warn('[GuidelineLoader] Error loading', file.name, e);
+            }
+        }
+        this.guidelines = guidelines;
+        console.log(`[GuidelineLoader] Loaded ${Object.keys(guidelines).length} guidelines`);
+        return guidelines;
+    }
+
+    parseMarkdown(md) {
+        const lines = md.split(/\r?\n/);
+        const sections = [];
+        let current = null;
+        for (const line of lines) {
+            const h = line.match(/^#\s+(.*)/);
+            if (h) {
+                if (current) sections.push(current);
+                current = { title: h[1], bullets: [] };
+            } else if (/^[-*]\s+/.test(line)) {
+                if (!current) current = { title: 'General', bullets: [] };
+                current.bullets.push(line.replace(/^[-*]\s+/, '').trim());
+            }
+        }
+        if (current) sections.push(current);
+        return sections;
+    }
+
+    getGuidelines() {
+        return this.guidelines;
+    }
+}

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -29,6 +29,7 @@ import { AuraManager } from './AuraManager.js';
 import { PossessionAIManager } from './possessionAIManager.js';
 import { CombatDecisionEngine } from './ai/CombatDecisionEngine.js';
 import { ReputationManager } from './ReputationManager.js';
+import GuidelineLoader from './guidelineLoader.js';
 // DataRecorder is only needed in a Node.js environment so we lazy-load it
 let DataRecorder = null;
 if (typeof process !== 'undefined' && process.versions?.node) {
@@ -68,5 +69,6 @@ export {
     SpeechBubbleManager,
     ReputationManager,
     CombatDecisionEngine,
+    GuidelineLoader,
     DataRecorder,
 };

--- a/tests/guidelineLoader.test.js
+++ b/tests/guidelineLoader.test.js
@@ -1,0 +1,31 @@
+import GuidelineLoader from '../src/managers/guidelineLoader.js';
+import { describe, test, assert } from './helpers.js';
+
+function mockFetch(responses) {
+    const fetch = async (url) => {
+        const key = Object.keys(responses).find(k => url.includes(k));
+        const value = responses[key];
+        if (Array.isArray(value)) {
+            return { ok: true, json: async () => value };
+        }
+        return { ok: true, text: async () => value };
+    };
+    return fetch;
+}
+
+describe('GuidelineLoader', () => {
+    test('loads and parses markdown', async () => {
+        const list = [
+            { name: 'guide.md', download_url: 'https://example.com/guide.md' }
+        ];
+        const md = '# Title\n- one\n- two';
+        const loader = new GuidelineLoader('dummy/path');
+        const origFetch = global.fetch;
+        global.fetch = mockFetch({ 'api.github.com': list, 'example.com': md });
+        const data = await loader.load();
+        global.fetch = origFetch;
+        assert.ok(data.guide);
+        assert.strictEqual(data.guide[0].title, 'Title');
+        assert.deepStrictEqual(data.guide[0].bullets, ['one', 'two']);
+    });
+});


### PR DESCRIPTION
## Summary
- load Markdown guidelines from GitHub via new `GuidelineLoader`
- expose loader in manager index and wire into `Game`
- add configuration for repository URL
- document usage in README
- test markdown parsing logic

## Testing
- `GROUP=GuidelineLoader node tests/guidelineLoader.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685a5200180483279059e068e3be4bc4