### PR TITLE
Integrate MbtiEngine into reputation system

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -164,7 +164,7 @@ export class Game {
         this.microEngine = new MicroEngine(this.eventManager);
         this.microCombatManager = new MicroCombatManager(this.eventManager);
         this.synergyManager = new Managers.SynergyManager(this.eventManager);
-        this.reputationManager = new Managers.ReputationManager(this.eventManager, this.mercenaryManager);
+        this.reputationManager = new Managers.ReputationManager(this.eventManager, this.mercenaryManager, this.metaAIManager.mbtiEngine);
         this.speechBubbleManager = this.managers.SpeechBubbleManager;
         this.equipmentRenderManager = this.managers.EquipmentRenderManager;
         this.mercenaryManager.equipmentRenderManager = this.equipmentRenderManager;


### PR DESCRIPTION
## Summary
- use `MbtiEngine` in `ReputationManager`
- pass `mbtiEngine` from `MetaAIManager` when constructing the reputation manager

## Testing
- `npm test` *(fails: tests hang before completion)*

------
https://chatgpt.com/codex/tasks/task_e_685a5855ba048327a7b4461779c4b19e