### PR TITLE
Fix ReputationManager init and missing mercenary list

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -164,7 +164,6 @@ export class Game {
         this.microEngine = new MicroEngine(this.eventManager);
         this.microCombatManager = new MicroCombatManager(this.eventManager);
         this.synergyManager = new Managers.SynergyManager(this.eventManager);
-        this.reputationManager = new Managers.ReputationManager(this.eventManager, this.mercenaryManager, this.metaAIManager.mbtiEngine);
         this.speechBubbleManager = this.managers.SpeechBubbleManager;
         this.equipmentRenderManager = this.managers.EquipmentRenderManager;
         this.mercenaryManager.equipmentRenderManager = this.equipmentRenderManager;
@@ -205,6 +204,11 @@ export class Game {
         this.uiManager.particleDecoratorManager = this.particleDecoratorManager;
         this.uiManager.vfxManager = this.vfxManager;
         this.metaAIManager = new MetaAIManager(this.eventManager);
+        this.reputationManager = new Managers.ReputationManager(
+            this.eventManager,
+            this.mercenaryManager,
+            this.metaAIManager.mbtiEngine
+        );
         this.cinematicManager = new CinematicManager(this);
         this.dataRecorder = new DataRecorder(this);
         this.dataRecorder.init();

--- a/src/managers/ReputationManager.js
+++ b/src/managers/ReputationManager.js
@@ -32,7 +32,13 @@ export class ReputationManager {
 
         if (change === 0) return;
 
-        const allies = this.mercenaryManager.mercenaries.filter(m => m.id !== entity.id && !m.isDead);
+        if (!this.mercenaryManager || !Array.isArray(this.mercenaryManager.mercenaries)) {
+            return;
+        }
+
+        const allies = this.mercenaryManager.mercenaries.filter(
+            (m) => m.id !== entity.id && !m.isDead
+        );
         for (const ally of allies) {
             memoryDB.addEvent({
                 actorId: entity.id,


### PR DESCRIPTION
## Summary
- avoid crash if mercenary manager not ready
- initialize ReputationManager after metaAIManager is available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a5fdc1934832780c4979df354c83e