### PR TITLE
Integrate MBTI model into MistakeEngine

### DIFF
--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -266,7 +266,7 @@ export class MetaAIManager {
                 }
                 
                 // 실수 엔진을 통해 최종 행동 결정
-                const finalAction = MistakeEngine.getFinalAction(member, action, currentContext);
+                const finalAction = MistakeEngine.getFinalAction(member, action, currentContext, this.mbtiEngine);
 
                 // AI가 행동을 결정한 직후 MBTI 엔진 처리
                 this.processMbti(member, { ...finalAction, context: currentContext });

--- a/src/managers/metaAIManager.js
+++ b/src/managers/metaAIManager.js
@@ -87,7 +87,7 @@ export class MetaAIManager extends BaseMetaAI {
 
                 if (member.ai) {
                     const action = member.ai.decideAction(member, currentContext);
-                    const finalAction = MistakeEngine.getFinalAction(member, action, currentContext);
+                    const finalAction = MistakeEngine.getFinalAction(member, action, currentContext, this.mbtiEngine);
                     this.executeAction(member, finalAction, currentContext);
                 }
             }


### PR DESCRIPTION
## Summary
- compute mistake probability using MbtiEngine
- supply MbtiEngine when calculating final actions

## Testing
- `npm test` *(fails: only ai.test.js runs before process stops)*

------
https://chatgpt.com/codex/tasks/task_e_685a621e3f148327a87e0e88a63c6016