### PR TITLE
Enable mistake engine by default

### DIFF
--- a/config/gameSettings.js
+++ b/config/gameSettings.js
@@ -4,7 +4,7 @@ export const SETTINGS = {
     // 포그 오브 워 표시 여부를 제어합니다.
     ENABLE_FOG_OF_WAR: true,
     // AI의 인간적인 실수 허용 여부를 제어합니다.
-    ENABLE_MISTAKE_ENGINE: false,
+    ENABLE_MISTAKE_ENGINE: true,
     // guideline markdown files will be loaded from this GitHub API path
     // example: 'user/repo/contents/guidelines?ref=main'
     GUIDELINE_REPO_URL: '',


### PR DESCRIPTION
## Summary
- enable the Mistake Engine in game settings

## Testing
- `npm test` *(fails: process exits early?)*

------
https://chatgpt.com/codex/tasks/task_e_685a644273d08327a720fe7fd85e3c85