### PR TITLE
Add reputation and mistake engine tests

### DIFF
--- a/tests/mistakeEngine.test.js
+++ b/tests/mistakeEngine.test.js
@@ -1,0 +1,39 @@
+import { MistakeEngine } from '../src/managers/ai/MistakeEngine.js';
+import { describe, test, assert } from './helpers.js';
+
+function createProbEngine(prob) {
+    return {
+        model: { predict: () => ({ dataSync: () => [prob] }) },
+        tf: { dispose: () => {} },
+        buildInput: () => ({})
+    };
+}
+
+describe('MistakeEngine', () => {
+    test('returns mistake when probability exceeds threshold', () => {
+        const mbti = createProbEngine(0.8);
+        const entity = { id: 1, name: 'Merc', x: 0, y: 0, properties: { mistakeChance: 0 } };
+        const optimal = { type: 'move', target: { x: 1, y: 1 } };
+        const context = { allies: [ { id: 2, x: 5, y: 5 } ], settings: {}, game: {} };
+        const orig = Math.random;
+        let call = 0;
+        Math.random = () => { call++; return call === 1 ? 0.1 : 0.6; };
+        const result = MistakeEngine.getFinalAction(entity, optimal, context, mbti);
+        Math.random = orig;
+        assert.notStrictEqual(result, optimal);
+        assert.ok(result.isMistake);
+    });
+
+    test('returns optimal action when probability is low', () => {
+        const mbti = createProbEngine(0.2);
+        const entity = { id: 1, name: 'Merc', x: 0, y: 0, properties: { mistakeChance: 0 } };
+        const optimal = { type: 'move', target: { x: 1, y: 1 } };
+        const context = { allies: [ { id: 2, x: 5, y: 5 } ], settings: {}, game: {} };
+        const orig = Math.random;
+        Math.random = () => 0.6; // 0.6 >= 0.2
+        const result = MistakeEngine.getFinalAction(entity, optimal, context, mbti);
+        Math.random = orig;
+        assert.strictEqual(result, optimal);
+    });
+});
+

--- a/tests/reputationManager.test.js
+++ b/tests/reputationManager.test.js
@@ -1,0 +1,59 @@
+import { ReputationManager } from '../src/managers/ReputationManager.js';
+import { EventManager } from '../src/managers/eventManager.js';
+import { memoryDB } from '../src/persistence/MemoryDB.js';
+import { describe, test, assert } from './helpers.js';
+
+function createDummyEngine(predClass) {
+    return {
+        model: {
+            predict: () => ({
+                argMax: () => ({ dataSync: () => [predClass] })
+            })
+        },
+        tf: { dispose: () => {} },
+        buildInput: () => ({})
+    };
+}
+
+describe('ReputationManager', () => {
+    test('records positive reputation when prediction is high', async () => {
+        const eventManager = new EventManager();
+        const mercenaryManager = { mercenaries: [ { id: 2, name: 'Ally', isDead: false } ] };
+        const dummy = createDummyEngine(4); // change = 2
+        const manager = new ReputationManager(eventManager, mercenaryManager, dummy);
+
+        const events = [];
+        const originalAdd = memoryDB.addEvent;
+        memoryDB.addEvent = async (data) => { events.push(data); };
+
+        const entity = { id: 1, name: 'Merc', isFriendly: true, isPlayer: false };
+        const action = { type: 'attack' };
+        const context = { game: {} };
+        await manager._onAction({ entity, action, context });
+
+        memoryDB.addEvent = originalAdd;
+        assert.strictEqual(events.length, 1);
+        assert.ok(events[0].reputationChange > 0);
+    });
+
+    test('records negative reputation when prediction is low', async () => {
+        const eventManager = new EventManager();
+        const mercenaryManager = { mercenaries: [ { id: 3, name: 'Ally', isDead: false } ] };
+        const dummy = createDummyEngine(0); // change = -2
+        const manager = new ReputationManager(eventManager, mercenaryManager, dummy);
+
+        const events = [];
+        const originalAdd = memoryDB.addEvent;
+        memoryDB.addEvent = async (data) => { events.push(data); };
+
+        const entity = { id: 2, name: 'Merc', isFriendly: true, isPlayer: false };
+        const action = { type: 'attack' };
+        const context = { game: {} };
+        await manager._onAction({ entity, action, context });
+
+        memoryDB.addEvent = originalAdd;
+        assert.strictEqual(events.length, 1);
+        assert.ok(events[0].reputationChange < 0);
+    });
+});
+


### PR DESCRIPTION
## Summary
- add ReputationManager tests for positive and negative reputation changes
- add MistakeEngine tests checking behavior changes under high probability

## Testing
- `node tests/reputationManager.test.js`
- `node tests/mistakeEngine.test.js`
- `npm test` *(fails: only ai.test.js runs)*

------
https://chatgpt.com/codex/tasks/task_e_685a67e39a548327ba93e2545aa244f8