### PR TITLE
Add reputation system toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 * **수족관 테스트 맵:** 통로가 넓은 미로 구조로 생성되어 길찾기 실험과 신규 기능 배치를 손쉽게 확인할 수 있습니다.
 * **포그 오브 워 토글:** `config/gameSettings.js`의 `ENABLE_FOG_OF_WAR` 값을 통해 안개 효과를 켜거나 끌 수 있습니다. 게임 도중 값을 변경하면 즉시 반영됩니다.
 * **TensorFlow 길찾기 토글:** `config/gameSettings.js`의 `ENABLE_TENSORFLOW_PATHING`을 활성화하면 학습된 모델을 이용해 보다 자연스러운 경로를 계산합니다. 기본값은 꺼져 있으며, 모델 파일이 없을 경우 자동으로 기존 BFS 로직을 사용합니다.
+* **평판 시스템 토글:** `config/gameSettings.js`의 `ENABLE_REPUTATION_SYSTEM` 값을 false로 설정하면 평판 기록과 모델 로드를 생략하여 성능을 높일 수 있습니다.
 
 ## 개발 원칙
 

--- a/config/gameSettings.js
+++ b/config/gameSettings.js
@@ -8,6 +8,9 @@ export const SETTINGS = {
     // TensorFlow 기반 길찾기 모델 사용 여부입니다.
     // 모델 파일이 없거나 실험적인 기능을 끄고 싶다면 false로 두세요.
     ENABLE_TENSORFLOW_PATHING: false,
+    // 평판 시스템 사용 여부입니다. 성능 문제가 있을 때 비활성화하면
+    // 메모리 기록과 모델 로드를 생략해 속도를 높일 수 있습니다.
+    ENABLE_REPUTATION_SYSTEM: true,
     // guideline markdown files will be loaded from this GitHub API path
     // example: 'user/repo/contents/guidelines?ref=main'
     GUIDELINE_REPO_URL: "https://github.com/cagecorn/doom-crawler-newest/blob/main/TensorFlow's%20room/guideline.md",

--- a/src/game.js
+++ b/src/game.js
@@ -205,10 +205,14 @@ export class Game {
         this.uiManager.particleDecoratorManager = this.particleDecoratorManager;
         this.uiManager.vfxManager = this.vfxManager;
         this.metaAIManager = new MetaAIManager(this.eventManager);
-        this.reputationManager = new ReputationManager(this.eventManager);
-        this.reputationManager.mercenaryManager = this.mercenaryManager;
-        this.reputationManager.mbtiEngine = this.metaAIManager.mbtiEngine;
-        this.reputationManager.loadReputationModel();
+        if (SETTINGS.ENABLE_REPUTATION_SYSTEM) {
+            this.reputationManager = new ReputationManager(this.eventManager);
+            this.reputationManager.mercenaryManager = this.mercenaryManager;
+            this.reputationManager.mbtiEngine = this.metaAIManager.mbtiEngine;
+            this.reputationManager.loadReputationModel();
+        } else {
+            this.reputationManager = null;
+        }
         this.cinematicManager = new CinematicManager(this);
         this.dataRecorder = new DataRecorder(this);
         this.dataRecorder.init();

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -5,6 +5,7 @@ import { TRAITS } from '../data/traits.js';
 import { SYNERGIES } from '../data/synergies.js';
 import { ARTIFACTS } from '../data/artifacts.js';
 import { memoryDB } from '../persistence/MemoryDB.js';
+import { SETTINGS } from '../../config/gameSettings.js';
 
 export class UIManager {
     constructor() {
@@ -35,6 +36,10 @@ export class UIManager {
         this.closeMercDetailBtn = document.getElementById('close-merc-detail-btn');
         this.mercenaryPanel = document.getElementById('mercenary-panel');
         this.mercenaryList = document.getElementById('mercenary-list');
+        this.settings = SETTINGS;
+        if (this.reputationHistoryPanel && !this.settings.ENABLE_REPUTATION_SYSTEM) {
+            this.reputationHistoryPanel.style.display = 'none';
+        }
         // 장착 대상 선택 패널 요소
         this.equipTargetPanel = document.getElementById('equipment-target-panel');
         this.equipTargetList = document.getElementById('equipment-target-list');
@@ -288,7 +293,7 @@ export class UIManager {
             });
         }
 
-        if (this.reputationHistoryPanel) {
+        if (this.settings.ENABLE_REPUTATION_SYSTEM && this.reputationHistoryPanel) {
             this.reputationHistoryPanel.innerHTML = '';
             const history = await memoryDB.getEventsFor(mercenary.id);
             history.forEach(ev => {
@@ -297,6 +302,8 @@ export class UIManager {
                 div.style.color = ev.reputationChange > 0 ? 'green' : 'red';
                 this.reputationHistoryPanel.appendChild(div);
             });
+        } else if (this.reputationHistoryPanel) {
+            this.reputationHistoryPanel.innerHTML = '';
         }
 
         this.mercDetailPanel.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- allow disabling reputation features via `ENABLE_REPUTATION_SYSTEM`
- hide reputation UI when disabled
- skip reputation manager initialization when disabled
- document new option in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a88b93e6483278365dc800f278dac