### PR TITLE
Add draggable UI windows

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,9 +80,9 @@
         <div class="log-title">-- SYSTEM LOG --</div>
         <div id="system-log-content"></div>
     </div>
-    <div id="mercenary-detail-panel" class="modal-panel ui-frame hidden">
+    <div id="mercenary-detail-panel" class="modal-panel ui-frame window draggable-window hidden">
         <button id="close-merc-detail-btn" class="close-btn">X</button>
-        <h2 id="merc-detail-name">용병 이름</h2>
+        <h2 id="merc-detail-name" class="window-header">용병 이름</h2>
         <div class="stats-content-box sheet-container">
             <div class="sheet-left">
                 <div id="merc-equipment-section">
@@ -114,16 +114,16 @@
         </div>
     </div>
 
-    <div id="equipment-target-panel" class="modal-panel ui-frame hidden">
+    <div id="equipment-target-panel" class="modal-panel ui-frame window draggable-window hidden">
         <button id="close-equip-target-btn" class="close-btn">X</button>
-        <h2>누구에게 장착하시겠습니까?</h2>
+        <h2 class="window-header">누구에게 장착하시겠습니까?</h2>
         <div id="equipment-target-list">
         </div>
     </div>
 
-    <div id="inventory-panel" class="modal-panel wide ui-frame hidden">
+    <div id="inventory-panel" class="modal-panel wide ui-frame window draggable-window hidden">
         <button class="close-btn" data-panel-id="inventory">X</button>
-        <h2>🎒 인벤토리</h2>
+        <h2 class="window-header">🎒 인벤토리</h2>
         <div class="inventory-container">
             <div class="inventory-left">
                 <h3>✨ 장착 중</h3>
@@ -152,16 +152,16 @@
         </div>
     </div>
 
-    <div id="mercenary-panel" class="modal-panel wide ui-frame hidden">
+    <div id="mercenary-panel" class="modal-panel wide ui-frame window draggable-window hidden">
         <button class="close-btn" data-panel-id="mercenary-panel">X</button>
-        <h2>🗡️ 용병 부대</h2>
+        <h2 class="window-header">🗡️ 용병 부대</h2>
         <div id="mercenary-list"></div>
     </div>
 
     <!-- 캐릭터 스탯을 표시하는 패널 -->
-    <div id="character-sheet-panel" class="modal-panel ui-frame hidden">
+    <div id="character-sheet-panel" class="modal-panel ui-frame window draggable-window hidden">
         <button class="close-btn" data-panel-id="character-sheet-panel">X</button>
-        <h2 id="sheet-character-name">캐릭터</h2>
+        <h2 id="sheet-character-name" class="window-header">캐릭터</h2>
         <div class="stats-content-box sheet-container">
             <div class="sheet-left">
                 <div id="sheet-equipment" class="equipment-slots">

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -6,6 +6,7 @@ import { SYNERGIES } from '../data/synergies.js';
 import { ARTIFACTS } from '../data/artifacts.js';
 import { memoryDB } from '../persistence/MemoryDB.js';
 import { SETTINGS } from '../../config/gameSettings.js';
+import { Draggable } from '../utils/Draggable.js';
 
 export class UIManager {
     constructor() {
@@ -59,6 +60,9 @@ export class UIManager {
         this._isInitialized = false;
         this.particleDecoratorManager = null;
         this.vfxManager = null;
+
+        this.draggables = [];
+        this._initDraggables();
 
         // 스탯 표시용 이름 매핑
         this.statDisplayNames = {
@@ -891,6 +895,22 @@ export class UIManager {
             if (stats) html += `<br><em>${stats}</em>`;
         }
         return html;
+    }
+
+    _initDraggables() {
+        const pairs = [
+            [this.mercDetailPanel, this.mercDetailPanel?.querySelector('.window-header')],
+            [this.equipTargetPanel, this.equipTargetPanel?.querySelector('.window-header')],
+            [this.inventoryPanel, this.inventoryPanel?.querySelector('.window-header')],
+            [this.mercenaryPanel, this.mercenaryPanel?.querySelector('.window-header')],
+            [this.characterSheetPanel, this.characterSheetPanel?.querySelector('.window-header')],
+        ];
+        pairs.forEach(([panel, header]) => {
+            if (panel) {
+                panel.classList.add('draggable-window', 'window');
+                new Draggable(panel, header || panel);
+            }
+        });
     }
 
     _attachTooltip(element, html) {

--- a/src/utils/Draggable.js
+++ b/src/utils/Draggable.js
@@ -1,0 +1,50 @@
+export class Draggable {
+    constructor(elementToDrag, handleElement) {
+        this.elementToDrag = elementToDrag;
+        this.handleElement = handleElement || elementToDrag;
+        this.isDragging = false;
+        this.initialX = 0;
+        this.initialY = 0;
+        this.offsetX = 0;
+        this.offsetY = 0;
+        this._onMouseDown = this.onMouseDown.bind(this);
+        this._onMouseMove = this.onMouseMove.bind(this);
+        this._onMouseUp = this.onMouseUp.bind(this);
+        this.handleElement.addEventListener('mousedown', this._onMouseDown);
+    }
+
+    onMouseDown(e) {
+        e.preventDefault();
+        this.isDragging = true;
+        this.initialX = e.clientX;
+        this.initialY = e.clientY;
+        this.offsetX = this.elementToDrag.offsetLeft;
+        this.offsetY = this.elementToDrag.offsetTop;
+        this.bringToFront();
+        document.addEventListener('mousemove', this._onMouseMove);
+        document.addEventListener('mouseup', this._onMouseUp);
+        this.handleElement.style.cursor = 'grabbing';
+    }
+
+    onMouseMove(e) {
+        if (!this.isDragging) return;
+        const dx = e.clientX - this.initialX;
+        const dy = e.clientY - this.initialY;
+        this.elementToDrag.style.left = `${this.offsetX + dx}px`;
+        this.elementToDrag.style.top = `${this.offsetY + dy}px`;
+    }
+
+    onMouseUp() {
+        this.isDragging = false;
+        document.removeEventListener('mousemove', this._onMouseMove);
+        document.removeEventListener('mouseup', this._onMouseUp);
+        this.handleElement.style.cursor = 'grab';
+    }
+
+    bringToFront() {
+        document.querySelectorAll('.draggable-window').forEach(win => {
+            win.style.zIndex = 100;
+        });
+        this.elementToDrag.style.zIndex = 101;
+    }
+}

--- a/style.css
+++ b/style.css
@@ -440,3 +440,17 @@ body, html {
 .menu-btn:last-child {
     margin-right: 0;
 }
+
+/* Draggable window styling */
+.window {
+    position: absolute;
+    z-index: 100;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+}
+
+.window-header {
+    padding: 10px;
+    background-color: #333;
+    color: white;
+    cursor: grab;
+}


### PR DESCRIPTION
## Summary
- implement a reusable `Draggable` utility for moving DOM nodes
- style draggable windows and headers
- mark modal panels as draggable in `index.html`
- integrate draggable setup in `UIManager`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ac3d6c31c8327ba7c1961355d84aa