### PR TITLE
Add drag-and-drop equipment handling

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -211,6 +211,7 @@ export class Game {
         this.uiManager.mercenaryManager = this.mercenaryManager;
         this.uiManager.particleDecoratorManager = this.particleDecoratorManager;
         this.uiManager.vfxManager = this.vfxManager;
+        this.uiManager.eventManager = this.eventManager;
         this.metaAIManager = new MetaAIManager(this.eventManager);
         if (SETTINGS.ENABLE_REPUTATION_SYSTEM) {
             this.reputationManager = new ReputationManager(this.eventManager);
@@ -471,8 +472,13 @@ export class Game {
             findEntityByWeaponId: (weaponId) => {
                 const list = [this.gameState.player, ...this.mercenaryManager.mercenaries, ...this.monsterManager.monsters, ...(this.petManager?.pets || [])];
                 return list.find(e => e.equipment?.weapon && e.equipment.weapon.id === weaponId) || null;
+            },
+            getEntityById: (id) => {
+                const list = [this.gameState.player, ...this.mercenaryManager.mercenaries, ...this.monsterManager.monsters, ...(this.petManager?.pets || [])];
+                return list.find(e => e.id === id) || null;
             }
         };
+        this.equipmentManager.entityManager = this.entityManager;
         this.aspirationManager = new AspirationManager(this.eventManager, this.microWorld, this.effectManager, this.vfxManager, this.entityManager);
 
         // === 4. 용병 고용 로직 ===

--- a/style.css
+++ b/style.css
@@ -454,3 +454,25 @@ body, html {
     color: white;
     cursor: grab;
 }
+/* Drag & Drop inventory slots */
+.slot {
+    width: 64px;
+    height: 64px;
+    border: 1px solid #555;
+    background-color: #222;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+.slot.drag-over {
+    background-color: #444;
+    border-color: #fff;
+}
+.slot img {
+    max-width: 100%;
+    max-height: 100%;
+    cursor: grab;
+}
+.slot img.dragging {
+    opacity: 0.5;
+}


### PR DESCRIPTION
## Summary
- add CSS for drag-drop slots
- support drag/drop UI in `UIManager`
- handle equipment swap requests in `EquipmentManager`
- wire UI manager to game event manager and provide entity lookup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ac6a5a3c08327aeaec44ab11d3e3d