### PR TITLE
Unify character sheet and add drag/drop inventory

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,6 +175,7 @@
                 <div class="equip-slot" data-slot="accessory2"><span>장신구2</span></div>
                 </div>
                 <div id="sheet-inventory"></div>
+                <div id="sheet-skills" class="skill-list"></div>
             </div>
             <div class="sheet-right">
                 <div id="player-stats-container">

--- a/style.css
+++ b/style.css
@@ -259,8 +259,8 @@ body, html {
 }
 
 .modal-panel.wide {
-    width: 60vw;
-    max-width: 800px;
+    width: 80vw;
+    max-width: 1000px;
 }
 
 .inventory-container {
@@ -417,6 +417,12 @@ body, html {
 }
 
 #merc-skills {
+    display: flex;
+    gap: 5px;
+    padding: 5px 0;
+}
+
+#sheet-skills {
     display: flex;
     gap: 5px;
     padding: 5px 0;


### PR DESCRIPTION
## Summary
- unify info screen for all units via character-sheet-panel
- enable drag/drop equipment between characters with updated event data
- add skills display in character sheet
- enlarge inventory panel and add filters
- support inventory filtering and cross-entity item swaps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685acb3f89088327b91089eb88d780b3