### PR TITLE
Fix squad manager init

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -146,6 +146,7 @@ export class Game {
                 name !== 'EffectManager' &&
                 name !== 'SkillManager' &&
                 name !== 'ProjectileManager' &&
+                name !== 'SquadManager' &&
                 name !== 'DataRecorder'
         );
         for (const managerName of otherManagerNames) {


### PR DESCRIPTION
## Summary
- prevent SquadManager from initializing before MercenaryManager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ad7e997b4832783f0ea82b6f0d8e2