### PR TITLE
Add shock effect and thunder strike

### DIFF
--- a/codex's room/dev-log.md
+++ b/codex's room/dev-log.md
@@ -65,3 +65,8 @@
 - 이동 속도 증가 버프 `haste` 효과 및 스킬 추가.
 - 스킬 목록 문서에 `haste` 항목을 기록.
 - `effectManager.test.js`에 신속 효과 테스트를 작성.
+
+## 세션 15
+- 신규 감전 디버프 `shock` 효과 추가.
+- 근접 스킬 `thunder_strike`와 무기 `stun_baton`을 데이터에 정의.
+- `skills.md`에 뇌전 일격 항목을 기록.

--- a/skills.md
+++ b/skills.md
@@ -33,6 +33,7 @@
 | regression | 퇴행 | debuff, magic_down |
 | spell_weakness | 마법 취약 | debuff, magic_resist_down |
 | elemental_weakness | 원소 취약 | debuff, resist_down |
+| thunder_strike | 뇌전 일격 | attack, melee, electric |
 
 ### 스킬 비고
 

--- a/src/data/effects.js
+++ b/src/data/effects.js
@@ -188,6 +188,15 @@ export const EFFECTS = {
         overlayColor: 'rgba(255, 255, 0, 0.4)',
         particle: { type: 'electric', color: 'yellow' }
     },
+    shock: {
+        name: '감전',
+        type: 'dot',
+        duration: 300,
+        damagePerTurn: 4,
+        tags: ['status_ailment', 'shock', 'dot'],
+        overlayColor: 'rgba(230, 230, 50, 0.4)',
+        particle: { type: 'electric', color: 'yellow' }
+    },
     burn: {
         name: '화상',
         type: 'dot',

--- a/src/data/items.js
+++ b/src/data/items.js
@@ -276,6 +276,18 @@ export const ITEMS = {
         imageKey: 'dagger', stats: { attackSpeed: 0.3 },
         tier: 'normal', durability: 80, weight: 3, toughness: 2
     },
+    stun_baton: {
+        name: '스턴 바톤', type: 'weapon', damageDice: '1d6',
+        tags: ['melee', 'mace', 'electric'],
+        aspiration: {
+            personality: 'standard',
+            current: 50,
+            max: 100,
+            state: 'stable',
+        },
+        imageKey: 'mace', stats: { attackPower: 4 },
+        tier: 'normal', durability: 120, weight: 7, toughness: 4
+    },
     // --- 여기까지 ---
 
     // Parasite samples

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -275,6 +275,16 @@ export const SKILLS = {
         cooldown: 150,
         tags: ['skill', 'summon', 'magic', 'minion'],
     },
+    thunder_strike: {
+        id: 'thunder_strike',
+        name: '뇌전 일격',
+        description: '대상을 타격하여 감전 상태를 부여합니다.',
+        manaCost: 12,
+        cooldown: 80,
+        damageDice: '1d8+2',
+        tags: ['skill', 'attack', 'melee', 'electric'],
+        effects: { target: ['shock'] },
+    },
     teleport: {
         id: 'teleport',
         name: '텔레포트',


### PR DESCRIPTION
## Summary
- expand effect list with a `shock` debuff
- create melee skill `thunder_strike` that inflicts shock
- add `stun_baton` weapon
- document the skill
- log this session in Codex's dev log

## Testing
- `npm test` *(fails: TensorFlow libraries not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_685adef939cc8327a650df01ff0809f1