### PR TITLE
Add Fire God mercenary and toggle for possession AI

### DIFF
--- a/config/gameSettings.js
+++ b/config/gameSettings.js
@@ -21,6 +21,8 @@ export const SETTINGS = {
     // 평판 시스템 사용 여부입니다. 성능 문제가 있을 때 비활성화하면
     // 메모리 기록과 모델 로드를 생략해 속도를 높일 수 있습니다.
     ENABLE_REPUTATION_SYSTEM: false,
+    // 유령 빙의 AI 시스템 사용 여부입니다.
+    ENABLE_POSSESSION_SYSTEM: false,
     // guideline markdown files will be loaded from this GitHub API path
     // example: 'user/repo/contents/guidelines?ref=main'
     // Remote markdown guidelines are fetched via the GitHub API.

--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
                 <button id="hire-wizard">마법사 용병 고용 (50골드)</button>
                 <button id="hire-bard">음유시인 고용 (50골드)</button>
                 <button id="hire-summoner">소환사 용병 고용 (50골드)</button>
+                <button id="hire-fire-god">불의 신 고용 (100골드)</button>
                 <button id="save-game-btn">게임 저장</button>
             </div>
         </div>

--- a/src/data/jobs.js
+++ b/src/data/jobs.js
@@ -78,5 +78,21 @@ export const JOBS = {
             attackPower: 10,
         }
     },
+    fire_god: {
+        name: '불의 신',
+        description: '화염을 다루는 강력한 존재입니다.',
+        stats: {
+            strength: 12,
+            agility: 8,
+            endurance: 12,
+            focus: 10,
+            intelligence: 10,
+            movement: 5,
+            hp: 80,
+            attackPower: 35,
+            sizeInTiles_w: 2,
+            sizeInTiles_h: 2,
+        }
+    },
 };
 

--- a/src/factory.js
+++ b/src/factory.js
@@ -166,6 +166,19 @@ export class CharacterFactory {
                     merc.roleAI = new BardAI(gameRef);
                     merc.defaultRoleAI = merc.roleAI;
                     merc.fallbackAI = null; // disable default AI for bards
+                } else if (config.jobId === 'fire_god') {
+                    merc.skills.push(SKILLS.fire_nova.id);
+                    // 불의 신은 무기를 랜덤하게 지급합니다.
+                    const weaponIds = ['sword', 'axe', 'mace', 'staff', 'spear', 'estoc', 'scythe', 'whip'];
+                    const randId = weaponIds[Math.floor(Math.random() * weaponIds.length)];
+                    const weapon = this.itemFactory.create(randId, 0, 0, tileSize);
+                    if (weapon) {
+                        merc.equipment.weapon = weapon;
+                        if (merc.stats) merc.stats.updateEquipmentStats();
+                        if (typeof merc.updateAI === 'function') merc.updateAI();
+                    }
+                    merc.roleAI = null;
+                    merc.fallbackAI = new MeleeAI();
                 } else {
                     const skillId = Math.random() < 0.5 ? SKILLS.double_strike.id : SKILLS.charge_attack.id;
                     merc.skills.push(skillId);


### PR DESCRIPTION
## Summary
- create a `fire_god` job with large size and great stats
- load fire-god image and add hiring button
- allow hiring Fire God mercenary with random weapon
- implement possession AI toggle in settings and disable it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ae6845b6c8327b11048196b41a36a