### PR TITLE
Fix Fire God sprite and skill usage

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -1084,3 +1084,22 @@ export class ArcherAI extends AIArchetype {
         return { type: 'idle' };
     }
 }
+
+// --- 불의 신 전용 AI ---
+export class FireGodAI extends AIArchetype {
+    constructor() {
+        super();
+        this.melee = new MeleeAI();
+    }
+
+    decideAction(self, context) {
+        const { enemies } = context;
+        const nearEnemy = (enemies || []).find(e =>
+            Math.hypot(e.x - self.x, e.y - self.y) <= self.attackRange * 1.5);
+        const fireNova = this._findReadySkill(self, s => s.id === SKILLS.fire_nova.id);
+        if (fireNova && nearEnemy) {
+            return { type: 'skill', target: nearEnemy, skillId: SKILLS.fire_nova.id };
+        }
+        return this.melee.decideAction(self, context);
+    }
+}

--- a/src/factory.js
+++ b/src/factory.js
@@ -10,7 +10,7 @@ import { EMBLEMS } from './data/emblems.js';
 import { PREFIXES, SUFFIXES } from './data/affixes.js';
 import { JOBS } from './data/jobs.js';
 import { SKILLS } from './data/skills.js';
-import { MeleeAI, RangedAI, HealerAI, BardAI, SummonerAI, WizardAI, WarriorAI, ArcherAI } from './ai.js';
+import { MeleeAI, RangedAI, HealerAI, BardAI, SummonerAI, WizardAI, WarriorAI, ArcherAI, FireGodAI } from './ai.js';
 import { SupportAI } from './ai/SupportAI.js';
 import { SupportEngine } from './systems/SupportEngine.js';
 import { MBTI_TYPES } from './data/mbti.js';
@@ -178,7 +178,7 @@ export class CharacterFactory {
                         if (typeof merc.updateAI === 'function') merc.updateAI();
                     }
                     merc.roleAI = null;
-                    merc.fallbackAI = new MeleeAI();
+                    merc.fallbackAI = new FireGodAI();
                 } else {
                     const skillId = Math.random() < 0.5 ? SKILLS.double_strike.id : SKILLS.charge_attack.id;
                     merc.skills.push(skillId);

--- a/src/game.js
+++ b/src/game.js
@@ -63,7 +63,8 @@ export class Game {
         this.loader.loadImage('wizard', 'assets/images/wizard.png');
         this.loader.loadImage('summoner', 'assets/images/summoner.png');
         this.loader.loadImage('bard', 'assets/images/bard.png');
-        this.loader.loadImage('fire-god', 'assets/images/fire-god.png');
+        // 불의 신 이미지 키를 jobId와 맞춰 'fire_god'으로 로드한다
+        this.loader.loadImage('fire_god', 'assets/images/fire-god.png');
         // 기존 호환성을 위해 기본 mercenary 키도 전사 이미지로 유지
         this.loader.loadImage('mercenary', 'assets/images/warrior.png');
         this.loader.loadImage('floor', 'assets/floor.png');

--- a/tests/unit/fireGodAI.test.js
+++ b/tests/unit/fireGodAI.test.js
@@ -1,0 +1,21 @@
+import { FireGodAI } from '../../src/ai.js';
+import { SKILLS } from '../../src/data/skills.js';
+import { describe, test, assert } from '../helpers.js';
+
+const mapStub = { tileSize: 1, isWallAt: () => false };
+
+describe('FireGodAI', () => {
+    test('uses fire nova when enemy nearby', () => {
+        const ai = new FireGodAI();
+        const self = {
+            x: 0, y: 0, attackRange: 10, tileSize: 1,
+            mp: 20, skills: [SKILLS.fire_nova.id],
+            skillCooldowns: {}
+        };
+        const enemy = { x: 5, y: 0 };
+        const ctx = { player: {}, allies: [self], enemies: [enemy], mapManager: mapStub };
+        const action = ai.decideAction(self, ctx);
+        assert.strictEqual(action.type, 'skill');
+        assert.strictEqual(action.skillId, SKILLS.fire_nova.id);
+    });
+});


### PR DESCRIPTION
## Summary
- correct asset key for Fire God image
- implement `FireGodAI` so the Fire God can use Fire Nova
- hook new AI in factory
- add unit test for `FireGodAI`

## Testing
- `node run-tests.mjs` *(fails: TensorFlow libraries missing)*

------
https://chatgpt.com/codex/tasks/task_e_685aed1374388327b8d8005debfa5eaf