### PR TITLE
Implement shared equipment handling and map improvements

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -177,8 +177,8 @@ export class CharacterFactory {
                         if (merc.stats) merc.stats.updateEquipmentStats();
                         if (typeof merc.updateAI === 'function') merc.updateAI();
                     }
-                    merc.roleAI = null;
-                    merc.fallbackAI = new FireGodAI();
+                    merc.roleAI = new FireGodAI();
+                    merc.fallbackAI = new MeleeAI();
                 } else {
                     const skillId = Math.random() < 0.5 ? SKILLS.double_strike.id : SKILLS.charge_attack.id;
                     merc.skills.push(skillId);

--- a/src/managers/equipmentManager.js
+++ b/src/managers/equipmentManager.js
@@ -21,11 +21,19 @@ export class EquipmentManager {
         if (oldItem?.tags.includes('emblem')) {
             this.eventManager?.publish('emblem_unequipped', { entity });
         }
+        // 장착 해제되는 아이템을 지정된 인벤토리로 이동
         if (oldItem && inventory) {
             inventory.push(oldItem);
         }
 
+        // 새 아이템 장착
         entity.equipment[slot] = item;
+
+        // 인벤토리에서 새 아이템 제거
+        if (inventory) {
+            const idx = inventory.indexOf(item);
+            if (idx > -1) inventory.splice(idx, 1);
+        }
 
         if (entity.stats && typeof entity.stats.updateEquipmentStats === 'function') {
             entity.stats.updateEquipmentStats();

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -198,6 +198,18 @@ export class UIManager {
             slots.forEach(slot => {
                 const item = entity.equipment ? entity.equipment[slot] : null;
                 const el = this.createSlotElement(entity, slot, item);
+
+                // 용병 장비 클릭 시 공용 인벤토리로 이동
+                if (!entity.isPlayer && item) {
+                    el.style.cursor = 'pointer';
+                    el.title = '클릭하여 공용 인벤토리로 이동';
+                    el.onclick = () => {
+                        this.game.equipmentManager.unequip(entity, slot, this.game.gameState.inventory);
+                        this.renderCharacterSheet(entity);
+                        this.renderInventory(this.game.gameState);
+                    };
+                }
+
                 this.sheetEquipment.appendChild(el);
             });
         }

--- a/src/worldEngine.js
+++ b/src/worldEngine.js
@@ -3,8 +3,8 @@ export class WorldEngine {
         this.game = game;
         this.assets = assets;
         this.worldMapImage = this.assets['world-tile'];
-        this.tileSize = this.game.mapManager?.tileSize || 64;
-        // 전투 맵과 동일한 배율을 유지하기 위해 고정된 타일 크기를 사용
+        // 전투 맵 타일 크기와 맞추기 위해 월드맵 계산용 타일 크기를 조금 크게 사용
+        this.tileSize = 192;
         this.worldWidth = this.tileSize * 40;
         this.worldHeight = this.tileSize * 40;
         this.camera = { x: 0, y: 0 };
@@ -155,23 +155,21 @@ export class WorldEngine {
         const worldWidth = this.worldWidth;
         const worldHeight = this.worldHeight;
 
-        // 전체 영역을 바다 타일 패턴으로 채움
+        // 렌더링에 사용할 작은 타일 크기
+        const renderTileSize = 64;
+
+        // 전체 영역을 바다 타일로 채움
         const seaPattern = ctx.createPattern(seaTileImg, 'repeat');
         if (seaPattern) {
             ctx.fillStyle = seaPattern;
             ctx.fillRect(0, 0, worldWidth, worldHeight);
         }
 
-        // world-tile 이미지를 그대로 반복해 육지 패턴 생성
-        const landPattern = ctx.createPattern(worldTileImg, 'repeat');
-        if (landPattern) {
-            ctx.fillStyle = landPattern;
-            ctx.fillRect(
-                this.tileSize,
-                this.tileSize,
-                worldWidth - 2 * this.tileSize,
-                worldHeight - 2 * this.tileSize
-            );
+        // 육지를 작은 타일 이미지로 반복 렌더링
+        for (let y = this.tileSize; y < worldHeight - this.tileSize; y += renderTileSize) {
+            for (let x = this.tileSize; x < worldWidth - this.tileSize; x += renderTileSize) {
+                ctx.drawImage(worldTileImg, x, y, renderTileSize, renderTileSize);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- update equipment manager to properly move items between inventory and slots
- allow clicking mercenary equipment to unequip into the player's inventory
- render world map with smaller repeat tiles and adjust tile size
- prioritize FireGodAI by assigning it as role AI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685af48902888327a1b1c7d23d750a0c