### PR TITLE
Implement shared equipment handling and fix FireGod AI

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -1100,6 +1100,7 @@ export class FireGodAI extends AIArchetype {
         if (fireNova && nearEnemy) {
             return { type: 'skill', target: nearEnemy, skillId: SKILLS.fire_nova.id };
         }
-        return this.melee.decideAction(self, context);
+        // 역할 AI에서 추가 행동이 없으면 무기 AI나 기본 AI가 처리하도록 함
+        return { type: 'idle' };
     }
 }

--- a/src/factory.js
+++ b/src/factory.js
@@ -177,8 +177,8 @@ export class CharacterFactory {
                         if (merc.stats) merc.stats.updateEquipmentStats();
                         if (typeof merc.updateAI === 'function') merc.updateAI();
                     }
-                    merc.roleAI = null;
-                    merc.fallbackAI = new FireGodAI();
+                    merc.roleAI = new FireGodAI();
+                    merc.fallbackAI = new MeleeAI();
                 } else {
                     const skillId = Math.random() < 0.5 ? SKILLS.double_strike.id : SKILLS.charge_attack.id;
                     merc.skills.push(skillId);

--- a/src/managers/equipmentManager.js
+++ b/src/managers/equipmentManager.js
@@ -21,11 +21,19 @@ export class EquipmentManager {
         if (oldItem?.tags.includes('emblem')) {
             this.eventManager?.publish('emblem_unequipped', { entity });
         }
+        // 장착 해제되는 아이템을 지정된 인벤토리로 이동
         if (oldItem && inventory) {
             inventory.push(oldItem);
         }
 
+        // 새 아이템 장착
         entity.equipment[slot] = item;
+
+        // 인벤토리에서 새 아이템 제거
+        if (inventory) {
+            const idx = inventory.indexOf(item);
+            if (idx > -1) inventory.splice(idx, 1);
+        }
 
         if (entity.stats && typeof entity.stats.updateEquipmentStats === 'function') {
             entity.stats.updateEquipmentStats();

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -198,6 +198,21 @@ export class UIManager {
             slots.forEach(slot => {
                 const item = entity.equipment ? entity.equipment[slot] : null;
                 const el = this.createSlotElement(entity, slot, item);
+
+                // 용병 장비 클릭 시 공용 인벤토리로 이동
+                if (!entity.isPlayer && item) {
+                    el.style.cursor = 'pointer';
+                    el.title = '클릭하여 공용 인벤토리로 이동';
+                    el.onclick = () => {
+                        const g = this.game || (typeof game !== 'undefined' ? game : null);
+                        if (g) {
+                            g.equipmentManager.unequip(entity, slot, g.gameState.inventory);
+                            this.renderCharacterSheet(entity);
+                            this.renderInventory(g.gameState);
+                        }
+                    };
+                }
+
                 this.sheetEquipment.appendChild(el);
             });
         }
@@ -795,6 +810,23 @@ export class UIManager {
             img.addEventListener('dragend', () => img.classList.remove('dragging'));
             slot.appendChild(img);
             this._attachTooltip(slot, this._getItemTooltip(item));
+
+            // 클릭하여 장비 해제 후 공용 인벤토리로 이동
+            if (slotType !== 'inventory') {
+                slot.style.cursor = 'pointer';
+                slot.onclick = () => {
+                    const g = this.game || (typeof game !== 'undefined' ? game : null);
+                    if (g) {
+                        g.equipmentManager.unequip(owner, slotType, g.gameState.inventory);
+                        if (owner === g.gameState.player) {
+                            this.renderInventory(g.gameState);
+                        } else {
+                            this.renderCharacterSheet(owner);
+                            this.renderInventory(g.gameState);
+                        }
+                    }
+                };
+            }
         }
 
         return slot;

--- a/src/worldEngine.js
+++ b/src/worldEngine.js
@@ -3,8 +3,8 @@ export class WorldEngine {
         this.game = game;
         this.assets = assets;
         this.worldMapImage = this.assets['world-tile'];
-        this.tileSize = this.game.mapManager?.tileSize || 64;
-        // 전투 맵과 동일한 배율을 유지하기 위해 고정된 타일 크기를 사용
+        // 전투 맵과 동일한 타일 크기를 사용해 월드맵 크기를 계산
+        this.tileSize = this.game.mapManager?.tileSize || 192;
         this.worldWidth = this.tileSize * 40;
         this.worldHeight = this.tileSize * 40;
         this.camera = { x: 0, y: 0 };
@@ -155,23 +155,21 @@ export class WorldEngine {
         const worldWidth = this.worldWidth;
         const worldHeight = this.worldHeight;
 
-        // 전체 영역을 바다 타일 패턴으로 채움
+        // 전투 맵과 같은 크기의 타일을 반복하여 월드맵을 그린다
+        const renderTileSize = this.tileSize;
+
+        // 전체 영역을 바다 타일로 채움
         const seaPattern = ctx.createPattern(seaTileImg, 'repeat');
         if (seaPattern) {
             ctx.fillStyle = seaPattern;
             ctx.fillRect(0, 0, worldWidth, worldHeight);
         }
 
-        // world-tile 이미지를 그대로 반복해 육지 패턴 생성
-        const landPattern = ctx.createPattern(worldTileImg, 'repeat');
-        if (landPattern) {
-            ctx.fillStyle = landPattern;
-            ctx.fillRect(
-                this.tileSize,
-                this.tileSize,
-                worldWidth - 2 * this.tileSize,
-                worldHeight - 2 * this.tileSize
-            );
+        // 육지를 작은 타일 이미지로 반복 렌더링
+        for (let y = this.tileSize; y < worldHeight - this.tileSize; y += renderTileSize) {
+            for (let x = this.tileSize; x < worldWidth - this.tileSize; x += renderTileSize) {
+                ctx.drawImage(worldTileImg, x, y, renderTileSize, renderTileSize);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- adjust world map rendering to tile at player scale
- allow clicking equipped items to unequip into shared inventory
- make FireGodAI defer to weapon AI when not casting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685af48902888327a1b1c7d23d750a0c