### PR TITLE
Implement unequip UI window

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,6 +123,13 @@
         </div>
     </div>
 
+    <div id="unequip-panel" class="modal-panel ui-frame window draggable-window hidden">
+        <button id="close-unequip-panel" class="close-btn">X</button>
+        <h2 class="window-header">장비 해제</h2>
+        <div id="unequip-item-name"></div>
+        <button id="unequip-confirm-btn">해제</button>
+    </div>
+
     <div id="inventory-panel" class="modal-panel wide ui-frame window draggable-window hidden">
         <button class="close-btn" data-panel-id="inventory">X</button>
         <h2 class="window-header">🎒 인벤토리</h2>

--- a/style.css
+++ b/style.css
@@ -373,6 +373,12 @@ body, html {
     z-index: 250;
 }
 
+#unequip-panel {
+    width: 200px;
+    text-align: center;
+    z-index: 250;
+}
+
 #sheet-equipment .equip-slot {
     display: flex; justify-content: space-between; align-items: center;
     padding: 8px; margin-bottom: 5px; background-color: rgba(0,0,0,0.1);


### PR DESCRIPTION
## Summary
- add a small `unequip-panel` to confirm removing gear
- style unequip panel
- route equipment slot clicks to open unequip panel
- handle unequip confirmation in `UIManager`

## Testing
- `npm test` *(fails: TensorFlow loader reference error but some tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_685afc38a1548327a4d7a4ee514af445