### PR TITLE
Implement grid-based shared inventory

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -18,6 +18,7 @@ import { AssetLoader } from './assetLoader.js';
 import { MetaAIManager, STRATEGY } from './managers/ai-managers.js';
 import { SaveLoadManager } from './managers/saveLoadManager.js';
 import { LayerManager } from './managers/layerManager.js';
+import { createGridInventory } from './inventory.js';
 import { PathfindingManager } from './managers/pathfindingManager.js';
 import { MovementManager } from './managers/movementManager.js';
 import { FogManager } from './managers/fogManager.js';
@@ -347,7 +348,7 @@ export class Game {
         this.gameState = {
             currentState: 'WORLD',
             player,
-            inventory: [],
+            inventory: createGridInventory(4, 4),
             gold: 1000,
             statPoints: 5,
             camera: { x: 0, y: 0 },
@@ -1176,7 +1177,8 @@ export class Game {
             onEquipItem: (entity, item) => {
                 const targetInventory = entity.isPlayer ? gameState.inventory : (entity.consumables || entity.inventory || gameState.inventory);
                 this.equipmentManager.equip(entity, item, targetInventory);
-                gameState.inventory = gameState.inventory.filter(i => i !== item);
+                const idx = gameState.inventory.indexOf(item);
+                if (idx !== -1) gameState.inventory.splice(idx, 1);
                 this.uiManager.renderInventory(gameState);
             }
         });

--- a/src/inventory.js
+++ b/src/inventory.js
@@ -1,0 +1,60 @@
+export function createGridInventory(rows = 4, cols = 4) {
+    const slots = Array.from({ length: rows * cols }, () => null);
+    const inventory = {
+        rows,
+        cols,
+        slots,
+        push(item) {
+            const idx = slots.findIndex(s => s === null);
+            if (idx === -1) return false;
+            slots[idx] = item;
+            return true;
+        },
+        splice(index, deleteCount = 1) {
+            const removed = [];
+            for (let i = 0; i < deleteCount; i++) {
+                removed.push(slots[index + i]);
+                slots[index + i] = null;
+            }
+            return removed;
+        },
+        find(fn) {
+            return slots.find(s => s && fn(s));
+        },
+        filter(fn) {
+            return slots.filter(s => s && fn(s));
+        },
+        map(fn) {
+            return slots.map(fn);
+        },
+        indexOf(item) {
+            return slots.indexOf(item);
+        },
+        get length() {
+            return slots.length;
+        },
+        toArray() {
+            return slots.slice();
+        },
+        [Symbol.iterator]: function* () {
+            for (const item of slots) {
+                if (item) yield item;
+            }
+        }
+    };
+    return new Proxy(inventory, {
+        get(target, prop) {
+            if (prop in target) return target[prop];
+            if (!isNaN(prop)) return target.slots[prop];
+            return undefined;
+        },
+        set(target, prop, value) {
+            if (!isNaN(prop)) {
+                target.slots[prop] = value;
+                return true;
+            }
+            target[prop] = value;
+            return true;
+        }
+    });
+}

--- a/src/managers/saveLoadManager.js
+++ b/src/managers/saveLoadManager.js
@@ -12,7 +12,7 @@ export class SaveLoadManager {
             player: gameState.player.getSaveState(),
             gold: gameState.gold,
             statPoints: gameState.statPoints,
-            inventory: gameState.inventory.map(item => item.name), // 아이템은 이름만 저장
+            inventory: gameState.inventory.filter(it => it).map(item => item.name), // 아이템은 이름만 저장
             monsters: monsterManager.monsters.map(m => m.getSaveState()),
             mercenaries: mercenaryManager.mercenaries.map(m => m.getSaveState()),
         };

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -429,11 +429,13 @@ export class UIManager {
 
         this.inventoryListContainer.innerHTML = '';
         const filtered = gameState.inventory.filter(it => {
+            if (!it) return false;
             if (this.currentInventoryFilter === 'all') return true;
             return it.type === this.currentInventoryFilter || it.tags?.includes(this.currentInventoryFilter);
         });
-        filtered.forEach((item, index) => {
-            const slotDiv = this.createSlotElement(player, 'inventory', item, index);
+        filtered.forEach(item => {
+            const idx = gameState.inventory.indexOf(item);
+            const slotDiv = this.createSlotElement(player, 'inventory', item, idx);
             this.inventoryListContainer.appendChild(slotDiv);
         });
     }
@@ -538,7 +540,7 @@ export class UIManager {
         if (current.length !== this._lastInventory.length) return true;
         for (let i = 0; i < current.length; i++) {
             if (current[i] !== this._lastInventory[i]) return true;
-            if (current[i].quantity !== this._lastInventory[i].quantity) return true;
+            if (current[i] && this._lastInventory[i] && current[i].quantity !== this._lastInventory[i].quantity) return true;
         }
         return false;
     }

--- a/tests/integration/full-cycle.integration.test.js
+++ b/tests/integration/full-cycle.integration.test.js
@@ -3,6 +3,7 @@ import { EventManager } from '../../src/managers/eventManager.js';
 import { HealerAI } from '../../src/ai.js';
 import { SKILLS } from '../../src/data/skills.js';
 import { monsterDeathWorkflow } from '../../src/workflows.js';
+import { createGridInventory } from '../../src/inventory.js';
 
 // 풀 사이클을 간략히 검증하는 통합 테스트
 
@@ -27,7 +28,7 @@ describe('Full Cycle Integration Test', () => {
       hp: 50,
       maxHp: 50,
       gold: 100,
-      inventory: [],
+      inventory: createGridInventory(4, 4),
       stats: {
         get: (stat) => (stat === 'attackPower' ? 10 : 50),
         addExp: () => {},


### PR DESCRIPTION
## Summary
- introduce `createGridInventory` helper
- initialize game inventory as grid
- adjust UI rendering and item equip logic for grid
- save only non-empty inventory slots
- update integration test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b5c1b15b0832797094872dc36cf84