### PR TITLE
Refactor UI and introduce EntityManager

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,10 +100,6 @@
                         <div class="equip-slot" data-slot="accessory2"></div>
                     </div>
                 </div>
-                <div id="merc-inventory-section">
-                    <h3>인벤토리</h3>
-                    <div id="merc-inventory"></div>
-                </div>
             </div>
             <div class="sheet-right">
                 <div id="merc-stats-container"></div>
@@ -116,19 +112,7 @@
         </div>
     </div>
 
-    <div id="equipment-target-panel" class="modal-panel ui-frame window draggable-window hidden">
-        <button id="close-equip-target-btn" class="close-btn">X</button>
-        <h2 class="window-header">누구에게 장착하시겠습니까?</h2>
-        <div id="equipment-target-list">
-        </div>
-    </div>
 
-    <div id="unequip-panel" class="modal-panel ui-frame window draggable-window hidden">
-        <button id="close-unequip-panel" class="close-btn">X</button>
-        <h2 class="window-header">장비 해제</h2>
-        <div id="unequip-item-name"></div>
-        <button id="unequip-confirm-btn">해제</button>
-    </div>
 
     <div id="inventory-panel" class="modal-panel wide ui-frame window draggable-window hidden">
         <button class="close-btn" data-panel-id="inventory-panel">X</button> <h2 class="window-header">🎒 공동 인벤토리</h2>

--- a/src/managers/entityManager.js
+++ b/src/managers/entityManager.js
@@ -1,0 +1,54 @@
+export class EntityManager {
+    constructor(eventManager) {
+        this.eventManager = eventManager;
+        this.entities = new Map();
+        this.player = null;
+        this.mercenaries = [];
+        this.monsters = [];
+    }
+
+    init(player, mercenaries = [], monsters = []) {
+        this.player = player;
+        if (player) this.entities.set(player.id, player);
+
+        this.mercenaries = mercenaries;
+        for (const m of mercenaries) {
+            this.entities.set(m.id, m);
+        }
+
+        this.monsters = monsters;
+        for (const m of monsters) {
+            this.entities.set(m.id, m);
+        }
+    }
+
+    addEntity(entity) {
+        if (!entity) return;
+        this.entities.set(entity.id, entity);
+    }
+
+    getEntityById(id) {
+        return this.entities.get(id) || null;
+    }
+
+    findEntityByWeaponId(weaponId) {
+        for (const ent of this.entities.values()) {
+            if (ent.equipment?.weapon?.id === weaponId) {
+                return ent;
+            }
+        }
+        return null;
+    }
+
+    getPlayer() {
+        return this.player;
+    }
+
+    getMercenaries() {
+        return this.mercenaries;
+    }
+
+    getMonsters() {
+        return this.monsters;
+    }
+}

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -30,6 +30,7 @@ import { AuraManager } from './AuraManager.js';
 import { PossessionAIManager } from './possessionAIManager.js';
 import { CombatDecisionEngine } from './ai/CombatDecisionEngine.js';
 import { ReputationManager } from './ReputationManager.js';
+import { EntityManager } from './entityManager.js';
 import GuidelineLoader from './guidelineLoader.js';
 // DataRecorder is only needed in a Node.js environment so we lazy-load it
 let DataRecorder = null;
@@ -70,6 +71,7 @@ export {
     SpeechBubbleManager,
     SquadManager,
     ReputationManager,
+    EntityManager,
     CombatDecisionEngine,
     GuidelineLoader,
     DataRecorder,

--- a/style.css
+++ b/style.css
@@ -393,15 +393,6 @@ body, html {
     font-size: 12px;
 }
 
-#equipment-target-panel {
-    z-index: 250;
-}
-
-#unequip-panel {
-    width: 200px;
-    text-align: center;
-    z-index: 250;
-}
 
 #sheet-equipment .equip-slot {
     display: flex; justify-content: space-between; align-items: center;


### PR DESCRIPTION
## Summary
- prune outdated panels from `index.html`
- drop related styles
- remove old equip/unequip UI logic from `UIManager`
- equip items directly through drag & drop in `game.js`
- add `EntityManager` class and export it via managers index
- integrate `EntityManager` into game initialization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b8768485483278482419103f85fad