### PR TITLE
Apply patch to dynamic character sheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,16 +139,7 @@
         <h2 id="sheet-character-name" class="window-header">캐릭터</h2>
         <div class="stats-content-box sheet-container">
             <div class="sheet-left">
-                <div class="sheet-equipment equipment-slots">
-                <div class="equip-slot" data-slot="main_hand"><span>주무기</span></div>
-                <div class="equip-slot" data-slot="off_hand"><span>보조장비</span></div>
-                <div class="equip-slot" data-slot="armor"><span>갑옷</span></div>
-                <div class="equip-slot" data-slot="helmet"><span>투구</span></div>
-                <div class="equip-slot" data-slot="gloves"><span>장갑</span></div>
-                <div class="equip-slot" data-slot="boots"><span>신발</span></div>
-                <div class="equip-slot" data-slot="accessory1"><span>장신구1</span></div>
-                <div class="equip-slot" data-slot="accessory2"><span>장신구2</span></div>
-                </div>
+                <div class="sheet-equipment equipment-slots"></div>
                 <div class="sheet-inventory"></div>
                 <div class="sheet-skills skill-list"></div>
             </div>

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -671,23 +671,32 @@ export class UIManager {
     renderCharacterSheet(entity, panel) {
         if (!panel) return;
         const nameEl = panel.querySelector('#sheet-character-name');
-        if (nameEl) nameEl.textContent = `${entity.constructor.name} (Lv.${entity.stats.get('level')})`;
+        if (nameEl) nameEl.textContent = `${entity.name || entity.constructor.name} (Lv.${entity.stats.get('level')})`;
 
-        const equipSlots = panel.querySelectorAll('.equip-slot');
-        equipSlots.forEach(slotEl => {
-            const slotName = slotEl.dataset.slot;
-            const item = entity.equipment[slotName];
-            slotEl.innerHTML = '';
-            slotEl.dataset.targetInfo = JSON.stringify({ entityId: entity.id, slot: slotName });
+        const equipContainer = panel.querySelector('.sheet-equipment.equipment-slots');
+        if (equipContainer) {
+            equipContainer.innerHTML = '';
+            for (const slotName in entity.equipment) {
+                const slotEl = document.createElement('div');
+                slotEl.className = 'equip-slot';
+                slotEl.dataset.slot = slotName;
+                slotEl.dataset.targetInfo = JSON.stringify({ entityId: entity.id, slot: slotName });
 
-            if (item) {
-                const sourceInfo = { entityId: entity.id, slot: slotName };
-                slotEl.dataset.sourceInfo = JSON.stringify(sourceInfo);
-                this.renderItemInSlot(slotEl, item);
+                const label = document.createElement('span');
+                label.textContent = this.getSlotLabel(slotName);
+                slotEl.appendChild(label);
+
+                const item = entity.equipment[slotName];
+                if (item) {
+                    const sourceInfo = { entityId: entity.id, slot: slotName };
+                    slotEl.dataset.sourceInfo = JSON.stringify(sourceInfo);
+                    this.renderItemInSlot(slotEl, item);
+                }
+
+                this.setupDropTarget(slotEl);
+                equipContainer.appendChild(slotEl);
             }
-
-            this.setupDropTarget(slotEl);
-        });
+        }
 
         const invBox = panel.querySelector('.sheet-inventory');
         if (invBox) {
@@ -959,5 +968,19 @@ export class UIManager {
             this.eventManager?.subscribe('squad_data_changed', () => this.createSquadManagementUI());
             this._squadUIInitialized = true;
         }
+    }
+
+    getSlotLabel(slotName) {
+        const labels = {
+            main_hand: '주무기',
+            off_hand: '보조장비',
+            armor: '갑옷',
+            helmet: '투구',
+            gloves: '장갑',
+            boots: '신발',
+            accessory1: '장신구1',
+            accessory2: '장신구2'
+        };
+        return labels[slotName] || slotName;
     }
 }


### PR DESCRIPTION
## Summary
- simplify HTML template by removing static equipment slots
- dynamically render equipment slots inside `UIManager.renderCharacterSheet`
- add helper for localized slot labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b8a66b4c88327a64e5a2bf33718e4