### PR TITLE
Introduce DecisionEngine and unify AI modules

### DIFF
--- a/src/ai/actions.js
+++ b/src/ai/actions.js
@@ -1,0 +1,1 @@
+export * from '../data/ai-actions.js';

--- a/src/ai/archetypes.js
+++ b/src/ai/archetypes.js
@@ -1,0 +1,77 @@
+import { SKILLS } from '../data/skills.js';
+import * as Base from '../ai.js';
+
+export const AIArchetype = Base.AIArchetype;
+export const CompositeAI = Base.CompositeAI;
+export const MeleeAI = Base.MeleeAI;
+export const RangedAI = Base.RangedAI;
+export const HealerAI = Base.HealerAI;
+export const PurifierAI = Base.PurifierAI;
+export const WizardAI = Base.WizardAI;
+export const TankerGhostAI = Base.TankerGhostAI;
+export const RangedGhostAI = Base.RangedGhostAI;
+export const SupporterGhostAI = Base.SupporterGhostAI;
+export const CCGhostAI = Base.CCGhostAI;
+export const SummonerAI = Base.SummonerAI;
+export const BardAI = Base.BardAI;
+export const FearAI = Base.FearAI;
+export const ConfusionAI = Base.ConfusionAI;
+export const BerserkAI = Base.BerserkAI;
+export const CharmAI = Base.CharmAI;
+export const WarriorAI = Base.WarriorAI;
+export const ArcherAI = Base.ArcherAI;
+export const FireGodAI = Base.FireGodAI;
+
+export class SupportAI extends AIArchetype {
+    constructor(engine) {
+        super();
+        this.engine = engine;
+    }
+
+    decideAction(self, context) {
+        const { allies } = context;
+        const healTarget = this._findHealTarget(self, allies);
+        if (healTarget) {
+            const healSkill = this._findReadySkill(self, s => s.tags?.includes('healing'));
+            if (healSkill) {
+                return { type: 'skill', target: healTarget, skillId: healSkill.id };
+            }
+        }
+
+        const purifyTarget = this._findPurifyTarget(self, allies);
+        if (purifyTarget) {
+            const purifySkill = this._findReadySkill(self, s => s.tags?.includes('purify'));
+            if (purifySkill) {
+                return { type: 'skill', target: purifyTarget, skillId: purifySkill.id };
+            }
+        }
+
+        const potionTarget = this._findPotionTarget(self, allies);
+        if (potionTarget && self.hasItem?.('healing_potion')) {
+            return { type: 'use_item', target: potionTarget, itemId: 'healing_potion' };
+        }
+
+        return { type: 'idle' };
+    }
+
+    _findHealTarget(self, allies) {
+        return this.engine?.findHealTarget ? this.engine.findHealTarget(self, allies) : null;
+    }
+    _findPurifyTarget(self, allies) {
+        return this.engine?.findPurifyTarget ? this.engine.findPurifyTarget(self, allies) : null;
+    }
+    _findPotionTarget(self, allies) {
+        return allies.find(a => a.hp < a.maxHp * 0.5) || null;
+    }
+    _findReadySkill(self, filter) {
+        if (!Array.isArray(self.skills)) return null;
+        for (const id of self.skills) {
+            const skill = SKILLS[id];
+            if (!skill || !filter(skill)) continue;
+            if (self.mp >= skill.manaCost && (self.skillCooldowns[id] || 0) <= 0) {
+                return { id, skill };
+            }
+        }
+        return null;
+    }
+}

--- a/src/ai/engines/DecisionEngine.js
+++ b/src/ai/engines/DecisionEngine.js
@@ -1,0 +1,32 @@
+import { MistakeEngine } from './MistakeEngine.js';
+import { MbtiEngine } from './MbtiEngine.js';
+
+export class DecisionEngine {
+    constructor() {
+        this.mbtiEngine = new MbtiEngine();
+        this.mistakeEngine = new MistakeEngine();
+    }
+
+    decideFinalAction(entity, context, strategy = 'AGGRESSIVE') {
+        let baseAction = entity.ai?.decideAction(entity, context) || { type: 'idle' };
+
+        if (strategy === 'DEFENSIVE') {
+            const player = context.player;
+            const defensiveRadius = 150;
+            const dist = Math.hypot(entity.x - player.x, entity.y - player.y);
+            if (dist > defensiveRadius) {
+                return { type: 'move', target: player };
+            }
+        }
+
+        const mbtiAction = this.mbtiEngine.influenceAction
+            ? this.mbtiEngine.influenceAction(entity, baseAction, context)
+            : baseAction;
+
+        const finalAction = this.mistakeEngine.getFinalAction
+            ? this.mistakeEngine.getFinalAction(entity, mbtiAction, context)
+            : mbtiAction;
+
+        return finalAction;
+    }
+}

--- a/src/ai/engines/MbtiEngine.js
+++ b/src/ai/engines/MbtiEngine.js
@@ -1,0 +1,1 @@
+export * from '../../managers/ai/MbtiEngine.js';

--- a/src/ai/engines/MistakeEngine.js
+++ b/src/ai/engines/MistakeEngine.js
@@ -1,0 +1,1 @@
+export * from '../../managers/ai/MistakeEngine.js';

--- a/src/ai/engines/ScenarioEngine.js
+++ b/src/ai/engines/ScenarioEngine.js
@@ -1,0 +1,1 @@
+export * from '../../managers/ai/ScenarioEngine.js';

--- a/src/factory.js
+++ b/src/factory.js
@@ -11,7 +11,7 @@ import { PREFIXES, SUFFIXES } from './data/affixes.js';
 import { JOBS } from './data/jobs.js';
 import { SKILLS } from './data/skills.js';
 import { MeleeAI, RangedAI, HealerAI, BardAI, SummonerAI, WizardAI, WarriorAI, ArcherAI, FireGodAI } from './ai.js';
-import { SupportAI } from './ai/SupportAI.js';
+import { SupportAI } from './ai/archetypes.js';
 import { SupportEngine } from './systems/SupportEngine.js';
 import { MBTI_TYPES } from './data/mbti.js';
 import { PETS } from './data/pets.js';

--- a/src/managers/AIManager.js
+++ b/src/managers/AIManager.js
@@ -1,0 +1,36 @@
+import { DecisionEngine } from '../ai/engines/DecisionEngine.js';
+
+export class AIManager {
+    constructor(eventManager, squadManager) {
+        this.eventManager = eventManager;
+        this.squadManager = squadManager;
+        this.decisionEngine = new DecisionEngine();
+        this.aiEntities = new Set();
+    }
+
+    registerEntity(entity) {
+        if (entity.ai) {
+            this.aiEntities.add(entity);
+        }
+    }
+
+    unregisterEntity(entity) {
+        this.aiEntities.delete(entity);
+    }
+
+    update(context) {
+        for (const entity of this.aiEntities) {
+            if (entity.hp <= 0 || !entity.ai) continue;
+            const squad = this.squadManager?.getSquadForMerc(entity.id);
+            const strategy = squad ? squad.strategy : 'AGGRESSIVE';
+            const action = this.decisionEngine.decideFinalAction(entity, context, strategy);
+            this.executeAction(entity, action, context);
+        }
+    }
+
+    executeAction(entity, action, context) {
+        // placeholder for actual execution logic
+        if (!action) return;
+        this.eventManager?.publish('action_performed', { entity, action, context });
+    }
+}

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -24,6 +24,7 @@ import { EffectIconManager } from './effectIconManager.js';
 import { PetManager } from './petManager.js';
 import { SquadManager } from './squadManager.js';
 import { MetaAIManager } from './metaAIManager.js';
+import { AIManager } from './AIManager.js';
 import { SynergyManager } from '../micro/SynergyManager.js';
 import { SpeechBubbleManager } from './speechBubbleManager.js';
 import { AuraManager } from './AuraManager.js';
@@ -65,6 +66,7 @@ export {
     PetManager,
     EffectIconManager,
     MetaAIManager,
+    AIManager,
     PossessionAIManager,
     AuraManager,
     SynergyManager,


### PR DESCRIPTION
## Summary
- add new AI engines directory with DecisionEngine
- create AIManager and expose via managers index
- provide wrapper exports for MbtiEngine, MistakeEngine, ScenarioEngine
- unify AI archetypes and integrate SupportAI
- export AI actions via src/ai/actions.js
- update factory to import unified archetypes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b8bc59bb48327848faab7ce346923