### PR TITLE
Fix MbtiEngine initialization

### DIFF
--- a/src/ai/engines/DecisionEngine.js
+++ b/src/ai/engines/DecisionEngine.js
@@ -2,8 +2,8 @@ import { MistakeEngine } from './MistakeEngine.js';
 import { MbtiEngine } from './MbtiEngine.js';
 
 export class DecisionEngine {
-    constructor() {
-        this.mbtiEngine = new MbtiEngine();
+    constructor(eventManager = null) {
+        this.mbtiEngine = new MbtiEngine(eventManager);
         this.mistakeEngine = new MistakeEngine();
     }
 

--- a/src/managers/AIManager.js
+++ b/src/managers/AIManager.js
@@ -4,7 +4,7 @@ export class AIManager {
     constructor(eventManager, squadManager) {
         this.eventManager = eventManager;
         this.squadManager = squadManager;
-        this.decisionEngine = new DecisionEngine();
+        this.decisionEngine = new DecisionEngine(eventManager);
         this.aiEntities = new Set();
     }
 


### PR DESCRIPTION
## Summary
- ensure DecisionEngine passes EventManager to MbtiEngine
- update AIManager to forward its event manager to DecisionEngine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b944577d083278d81343dd11f2042