### PR TITLE
Implement lane-based unit movement

### DIFF
--- a/src/ai/archetypes.js
+++ b/src/ai/archetypes.js
@@ -75,3 +75,35 @@ export class SupportAI extends AIArchetype {
         return null;
     }
 }
+
+/**
+ * 지정된 라인을 따라 웨이포인트를 향해 자동으로 전진하는 AI.
+ * 도중에 적을 만나면 교전합니다.
+ */
+export class LanePusherAI extends AIArchetype {
+    decideAction(self, context) {
+        const { enemies, laneManager } = context;
+
+        // 1. 시야 내의 가장 가까운 적을 찾습니다.
+        const visibleEnemies = this._filterVisibleEnemies(self, enemies);
+        const nearestEnemy = this._findNearestEnemy(self, visibleEnemies);
+
+        // 2. 적이 공격 범위 내에 있으면, 교전을 우선합니다.
+        if (nearestEnemy && this.isInAttackRange(self, nearestEnemy)) {
+            return { type: 'attack', target: nearestEnemy };
+        }
+
+        // 3. 적이 없으면, 다음 웨이포인트를 향해 전진합니다.
+        const nextWaypoint = laneManager.getNextWaypoint(self);
+        if (nextWaypoint) {
+            const distanceToWaypoint = Math.hypot(nextWaypoint.x - self.x, nextWaypoint.y - self.y);
+            if (distanceToWaypoint < self.tileSize) {
+                self.currentWaypointIndex = (self.currentWaypointIndex || 0) + 1;
+            }
+            return { type: 'move', target: nextWaypoint };
+        }
+
+        // 모든 웨이포인트에 도달했거나 경로가 없으면 대기합니다.
+        return { type: 'idle' };
+    }
+}

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -15,6 +15,7 @@ import { ProjectileManager } from './projectileManager.js';
 import { ItemAIManager } from './item-ai-manager.js';
 import { MotionManager } from './motionManager.js';
 import { MovementManager } from './movementManager.js';
+import { LaneManager } from './laneManager.js';
 import { EquipmentRenderManager } from './equipmentRenderManager.js';
 import { ParticleDecoratorManager } from './particleDecoratorManager.js';
 import { TraitManager } from './traitManager.js';
@@ -58,6 +59,7 @@ export {
     ItemAIManager,
     MotionManager,
     MovementManager,
+    LaneManager,
     EquipmentRenderManager,
     ParticleDecoratorManager,
     TraitManager,

--- a/src/managers/laneManager.js
+++ b/src/managers/laneManager.js
@@ -1,0 +1,74 @@
+// src/managers/laneManager.js
+
+/**
+ * 3-Lane 맵의 경로(웨이포인트)를 관리합니다.
+ * 이 데이터는 나중에 맵 파일에서 직접 불러오도록 확장할 수 있습니다.
+ */
+export class LaneManager {
+    constructor(mapWidth, mapHeight) {
+        // 맵 크기에 따라 동적으로 웨이포인트를 설정합니다.
+        const laneY = {
+            TOP: mapHeight * 0.2,
+            MID: mapHeight * 0.5,
+            BOTTOM: mapHeight * 0.8,
+        };
+        const startX = {
+            LEFT: mapWidth * 0.1,
+            RIGHT: mapWidth * 0.9,
+        };
+        const endX = {
+            LEFT: mapWidth * 0.9,
+            RIGHT: mapWidth * 0.1,
+        };
+
+        this.waypoints = {
+            TOP: {
+                LEFT: [
+                    { x: startX.LEFT, y: laneY.TOP },
+                    { x: endX.LEFT, y: laneY.TOP },
+                ],
+                RIGHT: [
+                    { x: startX.RIGHT, y: laneY.TOP },
+                    { x: endX.RIGHT, y: laneY.TOP },
+                ],
+            },
+            MID: {
+                LEFT: [
+                    { x: startX.LEFT, y: laneY.MID },
+                    { x: endX.LEFT, y: laneY.MID },
+                ],
+                RIGHT: [
+                    { x: startX.RIGHT, y: laneY.MID },
+                    { x: endX.RIGHT, y: laneY.MID },
+                ],
+            },
+            BOTTOM: {
+                LEFT: [
+                    { x: startX.LEFT, y: laneY.BOTTOM },
+                    { x: endX.LEFT, y: laneY.BOTTOM },
+                ],
+                RIGHT: [
+                    { x: startX.RIGHT, y: laneY.BOTTOM },
+                    { x: endX.RIGHT, y: laneY.BOTTOM },
+                ],
+            },
+        };
+        console.log('[LaneManager] Initialized with waypoints.');
+    }
+
+    /**
+     * 특정 유닛의 다음 목표 웨이포인트를 반환합니다.
+     * @param {object} entity - lane, team, currentWaypointIndex 속성을 가진 유닛
+     * @returns {object|null} - {x, y} 좌표 또는 null
+     */
+    getNextWaypoint(entity) {
+        if (!entity.lane || !entity.team || !this.waypoints[entity.lane]?.[entity.team]) {
+            return null;
+        }
+
+        const path = this.waypoints[entity.lane][entity.team];
+        const nextIndex = entity.currentWaypointIndex || 0;
+
+        return path[nextIndex] || null;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `LaneManager` for 3-lane waypoint data
- add `LanePusherAI` archetype that advances along lane waypoints
- wire up lane manager in `Game` initialization
- assign lanes to squads and monsters and give them the new AI
- expose `LaneManager` in managers index and pass it through update context
- compute lane waypoints using map pixel dimensions instead of canvas size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b9f64fff08327a0c4fe3dd38476ac