### PR TITLE
Fix getMonsters undefined error

### DIFF
--- a/src/managers/monsterManager.js
+++ b/src/managers/monsterManager.js
@@ -77,6 +77,10 @@ export class MonsterManager {
         return null;
     }
 
+    getMonsters() {
+        return this.monsters;
+    }
+
     render(ctx) {
         for (const monster of this.monsters.filter(m => !m.isDying)) {
             if (monster.render) monster.render(ctx);


### PR DESCRIPTION
## Summary
- add a simple accessor method `getMonsters` to MonsterManager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ba479aef08327ab7ec58509371794