### PR TITLE
Add lane assignment manager with lane map updates

### DIFF
--- a/src/aquariumMap.js
+++ b/src/aquariumMap.js
@@ -1,24 +1,56 @@
 // src/aquariumMap.js
-// Specialized map where new features can be placed and tested
+// Fixed three-lane map for testing lane mechanics
 import { MapManager } from './map.js';
 
 export class AquariumMapManager extends MapManager {
     constructor(seed) {
         super(seed);
         this.name = 'aquarium';
-        // slightly narrower corridors for a tighter maze feel
-        this.corridorWidth = 6;
-        // regenerate with the new corridor width
+        this.corridorWidth = 3;
         this.map = this._generateMaze();
     }
 
+    // Generate a simple three-lane layout separated by walls. Left and right edges
+    // are open so all lanes converge at the bases.
     _generateMaze() {
-        // use the base maze generation with the adjusted corridor width
-        return super._generateMaze();
+        const map = Array.from({ length: this.height }, () =>
+            Array(this.width).fill(this.tileTypes.WALL)
+        );
+
+        const openArea = 6; // width of the bases at left and right
+        const half = Math.floor(this.corridorWidth / 2);
+        const lanes = [
+            Math.floor(this.height * 0.2),
+            Math.floor(this.height * 0.5),
+            Math.floor(this.height * 0.8)
+        ];
+
+        for (let x = 0; x < this.width; x++) {
+            const isBaseColumn = x < openArea || x >= this.width - openArea;
+            for (const laneY of lanes) {
+                for (let y = laneY - half; y <= laneY + half; y++) {
+                    if (y >= 0 && y < this.height) {
+                        if (isBaseColumn) {
+                            // Bases are fully open vertically
+                            map[y][x] = this.tileTypes.FLOOR;
+                        } else {
+                            map[y][x] = this.tileTypes.FLOOR;
+                        }
+                    }
+                }
+            }
+
+            if (isBaseColumn) {
+                // also open the rest of the base columns
+                for (let y = 0; y < this.height; y++) {
+                    map[y][x] = this.tileTypes.FLOOR;
+                }
+            }
+        }
+
+        return map;
     }
 
-    // Aquarium floors skip room generation to emphasize maze corridors.
-    _generateRooms(map) {
-        // no-op to keep corridors unobstructed
-    }
+    // disable room generation entirely
+    _generateRooms(map) {}
 }

--- a/src/game.js
+++ b/src/game.js
@@ -52,6 +52,7 @@ import { findEntitiesInRadius } from './utils/entityUtils.js';
 import { LaneManager } from './managers/laneManager.js';
 import { LaneRenderManager } from './managers/laneRenderManager.js';
 import { LanePusherAI } from './ai/archetypes.js';
+import { LaneAssignmentManager } from './managers/laneAssignmentManager.js';
 
 export class Game {
     constructor() {
@@ -241,6 +242,11 @@ export class Game {
         this.squadManager = new Managers.SquadManager(this.eventManager, this.mercenaryManager);
         this.uiManager.squadManager = this.squadManager;
         this.uiManager.createSquadManagementUI?.();
+        this.laneAssignmentManager = new LaneAssignmentManager({
+            laneManager: this.laneManager,
+            squadManager: this.squadManager,
+            eventManager: this.eventManager
+        });
         this.metaAIManager = new MetaAIManager(this.eventManager, this.squadManager);
         if (SETTINGS.ENABLE_REPUTATION_SYSTEM) {
             this.reputationManager = new ReputationManager(this.eventManager);
@@ -551,16 +557,17 @@ export class Game {
                     this.gameState.gold -= 50;
                     const newMerc = this.mercenaryManager.hireMercenary(
                         'warrior',
-                        this.gameState.player.x + this.mapManager.tileSize,
+                        this.gameState.player.x,
                         this.gameState.player.y,
                         this.mapManager.tileSize,
                         'player_party'
                     );
 
                     if (newMerc) {
+                        this.laneAssignmentManager.assignMercenaryToLane(newMerc);
+                        this.entityManager.addEntity(newMerc);
                         this.playerGroup.addMember(newMerc);
                         this.eventManager.publish('mercenary_hired', { mercenary: newMerc });
-                        this.eventManager.publish('log', { message: `전사 용병을 고용했습니다.` });
                     }
                 } else {
                     this.eventManager.publish('log', { message: `골드가 부족합니다.` });
@@ -575,16 +582,17 @@ export class Game {
                     this.gameState.gold -= 50;
                     const newMerc = this.mercenaryManager.hireMercenary(
                         'archer',
-                        this.gameState.player.x + this.mapManager.tileSize,
+                        this.gameState.player.x,
                         this.gameState.player.y,
                         this.mapManager.tileSize,
                         'player_party'
                     );
 
                     if (newMerc) {
+                        this.laneAssignmentManager.assignMercenaryToLane(newMerc);
+                        this.entityManager.addEntity(newMerc);
                         this.playerGroup.addMember(newMerc);
                         this.eventManager.publish('mercenary_hired', { mercenary: newMerc });
-                        this.eventManager.publish('log', { message: `궁수 용병을 고용했습니다.` });
                     }
                 } else {
                     this.eventManager.publish('log', { message: `골드가 부족합니다.` });
@@ -599,16 +607,17 @@ export class Game {
                     this.gameState.gold -= 50;
                     const newMerc = this.mercenaryManager.hireMercenary(
                         'healer',
-                        this.gameState.player.x + this.mapManager.tileSize,
+                        this.gameState.player.x,
                         this.gameState.player.y,
                         this.mapManager.tileSize,
                         'player_party'
                     );
 
                     if (newMerc) {
+                        this.laneAssignmentManager.assignMercenaryToLane(newMerc);
+                        this.entityManager.addEntity(newMerc);
                         this.playerGroup.addMember(newMerc);
                         this.eventManager.publish('mercenary_hired', { mercenary: newMerc });
-                        this.eventManager.publish('log', { message: `힐러 용병을 고용했습니다.` });
                     }
                 } else {
                     this.eventManager.publish('log', { message: `골드가 부족합니다.` });
@@ -623,16 +632,17 @@ export class Game {
                     this.gameState.gold -= 50;
                     const newMerc = this.mercenaryManager.hireMercenary(
                         'wizard',
-                        this.gameState.player.x + this.mapManager.tileSize,
+                        this.gameState.player.x,
                         this.gameState.player.y,
                         this.mapManager.tileSize,
                         'player_party'
                     );
 
                     if (newMerc) {
+                        this.laneAssignmentManager.assignMercenaryToLane(newMerc);
+                        this.entityManager.addEntity(newMerc);
                         this.playerGroup.addMember(newMerc);
                         this.eventManager.publish('mercenary_hired', { mercenary: newMerc });
-                        this.eventManager.publish('log', { message: `마법사 용병을 고용했습니다.` });
                     }
                 } else {
                     this.eventManager.publish('log', { message: `골드가 부족합니다.` });
@@ -647,16 +657,17 @@ export class Game {
                     this.gameState.gold -= 50;
                     const newMerc = this.mercenaryManager.hireMercenary(
                         'bard',
-                        this.gameState.player.x + this.mapManager.tileSize,
+                        this.gameState.player.x,
                         this.gameState.player.y,
                         this.mapManager.tileSize,
                         'player_party'
                     );
 
                     if (newMerc) {
+                        this.laneAssignmentManager.assignMercenaryToLane(newMerc);
+                        this.entityManager.addEntity(newMerc);
                         this.playerGroup.addMember(newMerc);
                         this.eventManager.publish('mercenary_hired', { mercenary: newMerc });
-                        this.eventManager.publish('log', { message: `음유시인 용병을 고용했습니다.` });
                     }
                 } else {
                     this.eventManager.publish('log', { message: `골드가 부족합니다.` });
@@ -671,16 +682,17 @@ export class Game {
                     this.gameState.gold -= 50;
                     const newMerc = this.mercenaryManager.hireMercenary(
                         'summoner',
-                        this.gameState.player.x + this.mapManager.tileSize,
+                        this.gameState.player.x,
                         this.gameState.player.y,
                         this.mapManager.tileSize,
                         'player_party'
                     );
 
                     if (newMerc) {
+                        this.laneAssignmentManager.assignMercenaryToLane(newMerc);
+                        this.entityManager.addEntity(newMerc);
                         this.playerGroup.addMember(newMerc);
                         this.eventManager.publish('mercenary_hired', { mercenary: newMerc });
-                        this.eventManager.publish('log', { message: `소환사 용병을 고용했습니다.` });
                     }
                 } else {
                     this.eventManager.publish('log', { message: `골드가 부족합니다.` });
@@ -695,16 +707,17 @@ export class Game {
                     this.gameState.gold -= 100;
                     const newMerc = this.mercenaryManager.hireMercenary(
                         'fire_god',
-                        this.gameState.player.x + this.mapManager.tileSize,
+                        this.gameState.player.x,
                         this.gameState.player.y,
                         this.mapManager.tileSize,
                         'player_party'
                     );
 
                     if (newMerc) {
+                        this.laneAssignmentManager.assignMercenaryToLane(newMerc);
+                        this.entityManager.addEntity(newMerc);
                         this.playerGroup.addMember(newMerc);
                         this.eventManager.publish('mercenary_hired', { mercenary: newMerc });
-                        this.eventManager.publish('log', { message: `불의 신을 고용했습니다.` });
                     }
                 } else {
                     this.eventManager.publish('log', { message: `골드가 부족합니다.` });

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -25,6 +25,7 @@ import { MicroItemAIManager } from './microItemAIManager.js';
 import { EffectIconManager } from './effectIconManager.js';
 import { PetManager } from './petManager.js';
 import { SquadManager } from './squadManager.js';
+import { LaneAssignmentManager } from './laneAssignmentManager.js';
 import { MetaAIManager } from './metaAIManager.js';
 import { AIManager } from './AIManager.js';
 import { SynergyManager } from '../micro/SynergyManager.js';
@@ -76,6 +77,7 @@ export {
     SynergyManager,
     SpeechBubbleManager,
     SquadManager,
+    LaneAssignmentManager,
     ReputationManager,
     EntityManager,
     CombatDecisionEngine,

--- a/src/managers/laneAssignmentManager.js
+++ b/src/managers/laneAssignmentManager.js
@@ -1,0 +1,51 @@
+// src/managers/laneAssignmentManager.js
+
+import { LanePusherAI } from '../ai/archetypes.js';
+
+export class LaneAssignmentManager {
+    constructor({ laneManager, squadManager, eventManager }) {
+        this.laneManager = laneManager;
+        this.squadManager = squadManager;
+        this.eventManager = eventManager;
+
+        this.nextLaneIndex = 0;
+        this.lanes = ['TOP', 'MID', 'BOTTOM'];
+    }
+
+    /**
+     * 새로 고용된 용병을 다음 라인에 배정하고 필요한 설정을 수행합니다.
+     * @param {Mercenary} mercenary - 새로 고용된 용병 객체
+     */
+    assignMercenaryToLane(mercenary) {
+        if (!mercenary) return;
+
+        // 1. 다음 라인을 순서대로 선택
+        const lane = this.lanes[this.nextLaneIndex];
+        const squadId = `squad_${this.nextLaneIndex + 1}`;
+        this.nextLaneIndex = (this.nextLaneIndex + 1) % this.lanes.length; // 다음 인덱스로 순환
+
+        // 2. 용병에게 라인, 팀, AI 정보 할당
+        mercenary.lane = lane;
+        mercenary.team = 'LEFT'; // 아군은 왼쪽 팀으로 가정
+        mercenary.ai = new LanePusherAI();
+        mercenary.currentWaypointIndex = 0;
+
+        // 3. 용병을 해당 라인 분대에 편성
+        this.squadManager.handleSquadAssignment({ mercId: mercenary.id, toSquadId: squadId });
+        // 분대 UI 업데이트를 위해 분대 이름을 라인 이름으로 설정
+        const squad = this.squadManager.getSquad(squadId);
+        if (squad) {
+            squad.name = lane;
+        }
+
+        // 4. 용병을 라인 시작점으로 이동
+        const startWaypoint = this.laneManager.getNextWaypoint(mercenary);
+        if (startWaypoint) {
+            mercenary.x = startWaypoint.x;
+            mercenary.y = startWaypoint.y;
+        }
+
+        // 5. 로그 이벤트 발행
+        this.eventManager.publish('log', { message: `${mercenary.name || '용병'}을(를) [${lane}] 라인에 고용했습니다.` });
+    }
+}


### PR DESCRIPTION
## Summary
- add LaneAssignmentManager to manage lane placement
- create fixed 3-lane AquariumMap layout
- instantiate LaneAssignmentManager and simplify mercenary hiring
- export LaneAssignmentManager in managers index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bb0796bcc83278d68abcf0fe95413