### PR TITLE
Fix lane assignment squad lookup

### DIFF
--- a/src/managers/squadManager.js
+++ b/src/managers/squadManager.js
@@ -70,4 +70,13 @@ export class SquadManager {
         }
         return null;
     }
+
+    /**
+     * 특정 ID를 가진 분대 객체를 반환합니다.
+     * @param {string} squadId - 조회할 분대의 ID
+     * @returns {object|null} 분대 객체 또는 null
+     */
+    getSquad(squadId) {
+        return this.squads[squadId] || null;
+    }
 }


### PR DESCRIPTION
## Summary
- add missing `getSquad` method to `SquadManager`
- use it in `LaneAssignmentManager`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bb3c0d80483278b8edefee5d0592a