### PR TITLE
Fix event loop and unequip guard

### DIFF
--- a/src/managers/equipmentManager.js
+++ b/src/managers/equipmentManager.js
@@ -59,7 +59,9 @@ export class EquipmentManager {
      * @param {Array|null} inventory - Optional array to store the removed item.
      */
     unequip(entity, slot, inventory = null) {
-        if (!slot || !entity.equipment[slot]) return;
+        if (!entity || !entity.equipment || !slot || !entity.equipment[slot]) {
+            return;
+        }
 
         const oldItem = entity.equipment[slot];
         if (oldItem?.tags.includes('emblem')) {

--- a/src/workflows.js
+++ b/src/workflows.js
@@ -66,8 +66,10 @@ export function disarmWorkflow(context) {
         color: 'orange'
     });
 
-    // Notify cinematic system of disarm event
-    eventManager.publish('weapon_disarmed', { attacker, defender: target });
+    // MicroCombatManager already fired the 'weapon_disarmed' event when the
+    // durability check failed. Re-emitting the same event here caused a second
+    // workflow execution with missing context. Simply perform the visuals and
+    // log without publishing the event again.
 }
 
 // === 방어구 파괴 워크플로우 ===
@@ -95,6 +97,7 @@ export function armorBreakWorkflow(context) {
         color: 'red'
     });
 
-    // Notify cinematic system of armor break event
-    eventManager.publish('armor_broken', { attacker, defender: target });
+    // MicroCombatManager already emitted 'armor_broken' when the armor's
+    // durability reached zero. Emitting it again here triggered a recursive
+    // workflow with incomplete data, so avoid re-publishing the event.
 }


### PR DESCRIPTION
## Summary
- prevent weapon/armor workflows from re-emitting their triggering events
- guard against undefined equipment in `EquipmentManager.unequip`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bb61cdb8483279286098237ead0ba