### PR TITLE
Fix aquarium map start and lane alignment

### DIFF
--- a/src/aquariumMap.js
+++ b/src/aquariumMap.js
@@ -6,7 +6,8 @@ export class AquariumMapManager extends MapManager {
     constructor(seed) {
         super(seed);
         this.name = 'aquarium';
-        this.corridorWidth = 3;
+        this.corridorWidth = 5; // widen lane width
+        this.openArea = 6;
         this.map = this._generateMaze();
     }
 
@@ -17,13 +18,15 @@ export class AquariumMapManager extends MapManager {
             Array(this.width).fill(this.tileTypes.WALL)
         );
 
-        const openArea = 6; // width of the bases at left and right
+        const openArea = this.openArea; // width of the bases at left and right
         const half = Math.floor(this.corridorWidth / 2);
         const lanes = [
             Math.floor(this.height * 0.2),
             Math.floor(this.height * 0.5),
             Math.floor(this.height * 0.8)
         ];
+        this.lanes = lanes;
+        this.laneCenters = lanes.map(l => l * this.tileSize + this.tileSize / 2);
 
         for (let x = 0; x < this.width; x++) {
             const isBaseColumn = x < openArea || x >= this.width - openArea;
@@ -53,4 +56,14 @@ export class AquariumMapManager extends MapManager {
 
     // disable room generation entirely
     _generateRooms(map) {}
+
+    getLaneCenters() {
+        return this.laneCenters;
+    }
+
+    getPlayerStartingPosition() {
+        const x = (this.openArea / 2) * this.tileSize - this.tileSize / 2;
+        const y = this.laneCenters[1]; // middle lane
+        return { x, y };
+    }
 }

--- a/src/game.js
+++ b/src/game.js
@@ -134,7 +134,8 @@ export class Game {
         this.mapManager = new AquariumMapManager();
         const mapPixelWidth = this.mapManager.width * this.mapManager.tileSize;
         const mapPixelHeight = this.mapManager.height * this.mapManager.tileSize;
-        this.laneManager = new LaneManager(mapPixelWidth, mapPixelHeight);
+        const laneCenters = this.mapManager.getLaneCenters ? this.mapManager.getLaneCenters() : null;
+        this.laneManager = new LaneManager(mapPixelWidth, mapPixelHeight, laneCenters);
         this.laneRenderManager = new LaneRenderManager(this.laneManager);
         this.saveLoadManager = new SaveLoadManager();
         this.turnManager = new TurnManager();
@@ -351,7 +352,12 @@ export class Game {
         this.monsterGroup = this.metaAIManager.createGroup('dungeon_monsters', STRATEGY.AGGRESSIVE);
 
         // === 2. 플레이어 생성 ===
-        const startPos = this.mapManager.getRandomFloorPosition() || { x: this.mapManager.tileSize, y: this.mapManager.tileSize };
+        let startPos;
+        if (typeof this.mapManager.getPlayerStartingPosition === 'function') {
+            startPos = this.mapManager.getPlayerStartingPosition();
+        } else {
+            startPos = this.mapManager.getRandomFloorPosition() || { x: this.mapManager.tileSize, y: this.mapManager.tileSize };
+        }
         const player = this.factory.create('player', {
             x: startPos.x,
             y: startPos.y,
@@ -395,51 +401,53 @@ export class Game {
         this.worldEngine.setPlayer(player);
 
         // 초기 아이템 배치
-        const potion = this.itemFactory.create(
-                                'potion',
-                                player.x + this.mapManager.tileSize,
-                                player.y,
-                                this.mapManager.tileSize);
-        const dagger = this.itemFactory.create('short_sword',
-                                player.x - this.mapManager.tileSize,
-                                player.y,
-                                this.mapManager.tileSize);
-        const bow = this.itemFactory.create('long_bow',
-                                player.x,
-                                player.y + this.mapManager.tileSize,
-                                this.mapManager.tileSize);
-        const violinBow = this.itemFactory.create('violin_bow',
-                                player.x + this.mapManager.tileSize,
-                                player.y - this.mapManager.tileSize,
-                                this.mapManager.tileSize);
-        const plateArmor = this.itemFactory.create('plate_armor',
-                                player.x + this.mapManager.tileSize * 2,
-                                player.y - this.mapManager.tileSize,
-                                this.mapManager.tileSize);
-        const foxEgg = this.itemFactory.create('pet_fox',
-                                player.x - this.mapManager.tileSize * 2,
-                                player.y,
-                                this.mapManager.tileSize);
-        const foxCharm = this.itemFactory.create('fox_charm',
-                                player.x,
-                                player.y - this.mapManager.tileSize * 2,
-                                this.mapManager.tileSize);
-        // --- 테스트용 휘장 아이템 4종 배치 ---
-        const emblemGuardian = this.itemFactory.create('emblem_guardian', player.x + 64, player.y + 64, this.mapManager.tileSize);
-        const emblemDestroyer = this.itemFactory.create('emblem_destroyer', player.x - 64, player.y + 64, this.mapManager.tileSize);
-        const emblemDevotion = this.itemFactory.create('emblem_devotion', player.x + 64, player.y - 64, this.mapManager.tileSize);
-        const emblemConductor = this.itemFactory.create('emblem_conductor', player.x - 64, player.y - 64, this.mapManager.tileSize);
-        this.itemManager.addItem(potion);
-        if (dagger) this.itemManager.addItem(dagger);
-        if (bow) this.itemManager.addItem(bow);
-        if (violinBow) this.itemManager.addItem(violinBow);
-        if (plateArmor) this.itemManager.addItem(plateArmor);
-        if (foxEgg) this.itemManager.addItem(foxEgg);
-        if (foxCharm) this.itemManager.addItem(foxCharm);
-        if(emblemGuardian) this.itemManager.addItem(emblemGuardian);
-        if(emblemDestroyer) this.itemManager.addItem(emblemDestroyer);
-        if(emblemDevotion) this.itemManager.addItem(emblemDevotion);
-        if(emblemConductor) this.itemManager.addItem(emblemConductor);
+        if (this.mapManager.name !== 'aquarium') {
+            const potion = this.itemFactory.create(
+                                    'potion',
+                                    player.x + this.mapManager.tileSize,
+                                    player.y,
+                                    this.mapManager.tileSize);
+            const dagger = this.itemFactory.create('short_sword',
+                                    player.x - this.mapManager.tileSize,
+                                    player.y,
+                                    this.mapManager.tileSize);
+            const bow = this.itemFactory.create('long_bow',
+                                    player.x,
+                                    player.y + this.mapManager.tileSize,
+                                    this.mapManager.tileSize);
+            const violinBow = this.itemFactory.create('violin_bow',
+                                    player.x + this.mapManager.tileSize,
+                                    player.y - this.mapManager.tileSize,
+                                    this.mapManager.tileSize);
+            const plateArmor = this.itemFactory.create('plate_armor',
+                                    player.x + this.mapManager.tileSize * 2,
+                                    player.y - this.mapManager.tileSize,
+                                    this.mapManager.tileSize);
+            const foxEgg = this.itemFactory.create('pet_fox',
+                                    player.x - this.mapManager.tileSize * 2,
+                                    player.y,
+                                    this.mapManager.tileSize);
+            const foxCharm = this.itemFactory.create('fox_charm',
+                                    player.x,
+                                    player.y - this.mapManager.tileSize * 2,
+                                    this.mapManager.tileSize);
+            // --- 테스트용 휘장 아이템 4종 배치 ---
+            const emblemGuardian = this.itemFactory.create('emblem_guardian', player.x + 64, player.y + 64, this.mapManager.tileSize);
+            const emblemDestroyer = this.itemFactory.create('emblem_destroyer', player.x - 64, player.y + 64, this.mapManager.tileSize);
+            const emblemDevotion = this.itemFactory.create('emblem_devotion', player.x + 64, player.y - 64, this.mapManager.tileSize);
+            const emblemConductor = this.itemFactory.create('emblem_conductor', player.x - 64, player.y - 64, this.mapManager.tileSize);
+            this.itemManager.addItem(potion);
+            if (dagger) this.itemManager.addItem(dagger);
+            if (bow) this.itemManager.addItem(bow);
+            if (violinBow) this.itemManager.addItem(violinBow);
+            if (plateArmor) this.itemManager.addItem(plateArmor);
+            if (foxEgg) this.itemManager.addItem(foxEgg);
+            if (foxCharm) this.itemManager.addItem(foxCharm);
+            if(emblemGuardian) this.itemManager.addItem(emblemGuardian);
+            if(emblemDestroyer) this.itemManager.addItem(emblemDestroyer);
+            if(emblemDevotion) this.itemManager.addItem(emblemDevotion);
+            if(emblemConductor) this.itemManager.addItem(emblemConductor);
+        }
 
         // === 3. 몬스터 생성 ===
         const monsters = [];

--- a/src/managers/laneManager.js
+++ b/src/managers/laneManager.js
@@ -5,11 +5,15 @@
  * 이 데이터는 나중에 맵 파일에서 직접 불러오도록 확장할 수 있습니다.
  */
 export class LaneManager {
-    constructor(mapWidth, mapHeight) {
+    constructor(mapWidth, mapHeight, lanePositions = null) {
         // 맵 크기에 따라 동적으로 웨이포인트를 설정합니다.
         this.mapWidth = mapWidth;
         this.mapHeight = mapHeight;
-        const laneY = {
+        const laneY = lanePositions ? {
+            TOP: lanePositions[0],
+            MID: lanePositions[1],
+            BOTTOM: lanePositions[2],
+        } : {
             TOP: mapHeight * 0.2,
             MID: mapHeight * 0.5,
             BOTTOM: mapHeight * 0.8,

--- a/src/managers/laneRenderManager.js
+++ b/src/managers/laneRenderManager.js
@@ -11,7 +11,7 @@ export class LaneRenderManager {
 
         ctx.save();
         ctx.strokeStyle = 'rgba(255,255,255,0.3)';
-        ctx.lineWidth = 2;
+        ctx.lineWidth = 4;
         const lines = [laneY.TOP, laneY.MID, laneY.BOTTOM];
         for (const y of lines) {
             ctx.beginPath();


### PR DESCRIPTION
## Summary
- widen aquarium lanes and store lane positions
- expose lane centers and starting position helpers
- adjust LaneManager to use provided lane centers
- align lane overlay lines and make them thicker
- spawn player at left start point and skip starting items in aquarium

## Testing
- `npm test --silent` *(fails: TensorFlow window not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685bb9c8a02883279f14f54b52223a6c