### PR TITLE
Add entrances to aquarium jungle

### DIFF
--- a/src/aquariumMap.js
+++ b/src/aquariumMap.js
@@ -57,6 +57,9 @@ export class AquariumMapManager extends MapManager {
             }
         }
 
+        // create entrances from each lane into the jungle areas
+        this._addJungleEntrances(map, lanes, half);
+
         return map;
     }
 
@@ -182,6 +185,38 @@ export class AquariumMapManager extends MapManager {
     _isValidMazePositionCustom(x, y, width, minY, maxY) {
         const margin = Math.ceil(width / 2);
         return x >= margin && x < this.width - margin && y >= minY && y < maxY;
+    }
+
+    _addJungleEntrances(map, lanes, half) {
+        const gateWidth = this.jungleWidth;
+        const gateHalf = Math.floor(gateWidth / 2);
+        const startX = this.openArea + gateHalf + 1;
+        const endX = this.width - this.openArea - gateHalf - 1;
+
+        for (let i = 0; i < lanes.length; i++) {
+            const laneY = lanes[i];
+            const sides = [];
+            if (i > 0) sides.push(-1);     // entrance to jungle above
+            if (i < lanes.length - 1) sides.push(1); // entrance to jungle below
+            if (sides.length === 0) continue;
+
+            const entranceCount = 3 + Math.floor(this._random() * 3); // 3-5
+            for (let e = 0; e < entranceCount; e++) {
+                const side = sides[e % sides.length];
+                const wallY = laneY + side * (half + 1);
+                const jungleY = wallY + side; // one tile into jungle
+                const x = Math.floor(this._random() * (endX - startX + 1)) + startX;
+
+                for (let dx = -gateHalf; dx <= gateHalf; dx++) {
+                    if (map[wallY] && map[wallY][x + dx] !== undefined) {
+                        map[wallY][x + dx] = this.tileTypes.FLOOR;
+                    }
+                    if (map[jungleY] && map[jungleY][x + dx] !== undefined) {
+                        map[jungleY][x + dx] = this.tileTypes.FLOOR;
+                    }
+                }
+            }
+        }
     }
 
     // disable room generation entirely

--- a/tests/unit/aquarium.test.js
+++ b/tests/unit/aquarium.test.js
@@ -64,4 +64,29 @@ describe('Aquarium', () => {
         assert.strictEqual(stats.get('maxHp'), (10 + base.endurance * 5) * 2);
         assert.ok(Math.abs(stats.get('attackPower')) < 0.001);
     });
+
+    test('Lanes have multiple jungle entrances', () => {
+        const m = new AquariumMapManager(3);
+        const half = Math.floor(m.corridorWidth / 2);
+        for (let i = 0; i < m.lanes.length; i++) {
+            const laneY = m.lanes[i];
+            let entrances = 0;
+            const sides = [];
+            if (i > 0) sides.push(-1);
+            if (i < m.lanes.length - 1) sides.push(1);
+            for (const dir of sides) {
+                const y = laneY + dir * (half + 1);
+                const inside = y + dir;
+                let lastWasWall = true;
+                for (let x = m.openArea; x < m.width - m.openArea; x++) {
+                    const wall = m.map[y][x] === m.tileTypes.WALL;
+                    if (!wall && lastWasWall && m.map[inside][x] === m.tileTypes.FLOOR && m.map[y - dir][x] === m.tileTypes.FLOOR) {
+                        entrances++;
+                    }
+                    lastWasWall = wall;
+                }
+            }
+            assert.ok(entrances >= 3, `lane ${i} has too few entrances`);
+        }
+    });
 });


### PR DESCRIPTION
## Summary
- connect jungle zones to lanes in `AquariumMapManager`
- add `_addJungleEntrances` helper
- test jungle entrances in aquarium map

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bd3a479248327acd71537d9ccaae4