### PR TITLE
Add Enemy Formation Manager and fix formation size

### DIFF
--- a/src/managers/enemyFormationManager.js
+++ b/src/managers/enemyFormationManager.js
@@ -1,0 +1,44 @@
+import { FormationManager } from './formationManager.js';
+import { MeleeAI, RangedAI, HealerAI } from '../ai.js';
+
+/**
+ * Specialized formation manager for enemy troops.
+ * Default rules:
+ *  - Melee units in row 1 (index 0)
+ *  - Ranged units in row 2 (index 1)
+ *  - Healers/Buffers in row 3 (index 2)
+ * Orientation is fixed to RIGHT so that enemies face left.
+ */
+export class EnemyFormationManager extends FormationManager {
+    constructor(rows = 3, cols = 3, tileSize = 192) {
+        super(rows, cols, tileSize, 'RIGHT');
+        this.rules = [];
+        this._registerDefaultRules();
+    }
+
+    _registerDefaultRules() {
+        this.addRule(m => m.ai instanceof MeleeAI, 0);
+        this.addRule(m => m.ai instanceof RangedAI, 1);
+        this.addRule(m => m.ai instanceof HealerAI, 2);
+    }
+
+    addRule(predicate, row) {
+        this.rules.push({ predicate, row });
+    }
+
+    arrange(enemies) {
+        const counts = Array(this.rows).fill(0);
+        for (const enemy of enemies) {
+            if (!enemy) continue;
+            let row = 0;
+            const rule = this.rules.find(r => r.predicate(enemy));
+            if (rule) row = rule.row;
+            const col = counts[row]++;
+            if (col >= this.cols) {
+                this.resize(this.rows, col + 1);
+            }
+            const slot = row * this.cols + col;
+            this.assign(slot, enemy.id);
+        }
+    }
+}

--- a/src/managers/formationManager.js
+++ b/src/managers/formationManager.js
@@ -1,9 +1,17 @@
 export class FormationManager {
-    constructor(rows = 3, cols = 3, tileSize = 192) {
-        this.rows = rows;
-        this.cols = cols;
+    constructor(rows = 3, cols = 3, tileSize = 192, orientation = 'LEFT') {
+        // sanitize parameters to avoid invalid array length errors
+        this.rows = Math.max(1, Math.floor(Number(rows) || 3));
+        this.cols = Math.max(1, Math.floor(Number(cols) || 3));
         this.tileSize = tileSize;
-        this.slots = Array(rows * cols).fill(null); // entity ids
+        this.orientation = orientation; // LEFT or RIGHT
+        this.slots = Array(this.rows * this.cols).fill(null); // entity ids
+    }
+
+    resize(rows, cols) {
+        this.rows = Math.max(1, Math.floor(Number(rows) || this.rows));
+        this.cols = Math.max(1, Math.floor(Number(cols) || this.cols));
+        this.slots = Array(this.rows * this.cols).fill(null);
     }
 
     assign(slotIndex, entityId) {
@@ -16,7 +24,8 @@ export class FormationManager {
     getSlotPosition(index) {
         const row = Math.floor(index / this.cols);
         const col = index % this.cols;
-        const offsetX = (col - Math.floor(this.cols / 2)) * this.tileSize;
+        let offsetX = (col - Math.floor(this.cols / 2)) * this.tileSize;
+        if (this.orientation === 'RIGHT') offsetX *= -1; // mirror for enemy side
         const offsetY = (row - Math.floor(this.rows / 2)) * this.tileSize;
         return { x: offsetX, y: offsetY };
     }

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -27,6 +27,7 @@ import { PetManager } from './petManager.js';
 import { SquadManager } from './squadManager.js';
 import { LaneAssignmentManager } from './laneAssignmentManager.js';
 import { FormationManager } from './formationManager.js';
+import { EnemyFormationManager } from './enemyFormationManager.js';
 import { MetaAIManager } from './metaAIManager.js';
 import { AIManager } from './AIManager.js';
 import { SynergyManager } from '../micro/SynergyManager.js';
@@ -72,6 +73,7 @@ export {
     PetManager,
     EffectIconManager,
     FormationManager,
+    EnemyFormationManager,
     MetaAIManager,
     AIManager,
     PossessionAIManager,

--- a/tests/unit/enemyFormationManager.test.js
+++ b/tests/unit/enemyFormationManager.test.js
@@ -1,0 +1,17 @@
+import { EnemyFormationManager } from '../../src/managers/enemyFormationManager.js';
+import { MeleeAI, RangedAI, HealerAI } from '../../src/ai.js';
+import { describe, test, assert } from '../helpers.js';
+
+describe('EnemyFormationManager', () => {
+    test('arrange by ai type', () => {
+        const fm = new EnemyFormationManager(3,3,10);
+        const m1 = { id: 'm1', ai: new MeleeAI() };
+        const m2 = { id: 'm2', ai: new RangedAI() };
+        const m3 = { id: 'm3', ai: new HealerAI() };
+        fm.arrange([m1, m2, m3]);
+        const rowOf = id => Math.floor(fm.slots.indexOf(id) / fm.cols);
+        assert.equal(rowOf(m1.id), 0);
+        assert.equal(rowOf(m2.id), 1);
+        assert.equal(rowOf(m3.id), 2);
+    });
+});


### PR DESCRIPTION
## Summary
- avoid `RangeError` in `FormationManager` by sanitizing rows/cols and add orientation support
- create `EnemyFormationManager` with default rules (melee front, ranged middle, healers rear)
- export new manager
- add unit test for enemy formation logic

## Testing
- `npm install nodejs npm`
- `node run-tests.mjs`

------
https://chatgpt.com/codex/tasks/task_e_685be5b5aeb483278cce82f04516d9e9