### PR TITLE
UI tweaks for merc details and squad grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,35 +82,6 @@
         <div class="log-title">-- SYSTEM LOG --</div>
         <div id="system-log-content"></div>
     </div>
-    <div id="mercenary-detail-panel" class="modal-panel ui-frame window draggable-window hidden">
-        <button id="close-merc-detail-btn" class="close-btn">X</button>
-        <h2 id="merc-detail-name" class="window-header">용병 이름</h2>
-        <div class="stats-content-box sheet-container">
-            <div class="sheet-left">
-                <div id="merc-equipment-section">
-                    <h3>장비</h3>
-                    <div id="merc-equipment" class="equipment-slots">
-                        <div class="equip-slot" data-slot="main_hand"></div>
-                        <div class="equip-slot" data-slot="off_hand"></div>
-                        <div class="equip-slot" data-slot="armor"></div>
-                        <div class="equip-slot" data-slot="helmet"></div>
-                        <div class="equip-slot" data-slot="gloves"></div>
-                        <div class="equip-slot" data-slot="boots"></div>
-                        <div class="equip-slot" data-slot="accessory1"></div>
-                        <div class="equip-slot" data-slot="accessory2"></div>
-                    </div>
-                </div>
-            </div>
-            <div class="sheet-right">
-                <div id="merc-stats-container"></div>
-                <div id="merc-skills-section">
-                    <h3>스킬</h3>
-                    <div id="merc-skills" class="skill-list"></div>
-                </div>
-                <div id="reputation-history-panel"></div>
-            </div>
-        </div>
-    </div>
 
 
 

--- a/src/game.js
+++ b/src/game.js
@@ -242,6 +242,7 @@ export class Game {
         this.effectIconManager = new Managers.EffectIconManager(this.eventManager, assets);
         // UIManager가 mercenaryManager에 접근할 수 있도록 설정
         this.uiManager.mercenaryManager = this.mercenaryManager;
+        this.mercenaryManager.setUIManager(this.uiManager);
         this.uiManager.particleDecoratorManager = this.particleDecoratorManager;
         this.uiManager.vfxManager = this.vfxManager;
         this.uiManager.eventManager = this.eventManager;
@@ -1339,10 +1340,9 @@ export class Game {
             );
 
             if (clickedMerc) {
-                if (this.uiManager.showMercenaryDetail) {
-                    this.uiManager.showMercenaryDetail(clickedMerc);
-                    if (this.uiManager.mercDetailPanel)
-                        this.gameState.isPaused = true;
+                if (this.mercenaryManager.showMercenaryDetail) {
+                    this.mercenaryManager.showMercenaryDetail(clickedMerc);
+                    this.gameState.isPaused = true;
                 }
                 return; // 용병을 클릭했으면 더 이상 진행 안 함
             }

--- a/src/managers/mercenaryManager.js
+++ b/src/managers/mercenaryManager.js
@@ -8,6 +8,7 @@ export class MercenaryManager {
         this.mercenaries = [];
         this.equipmentRenderManager = null;
         this.traitManager = null;
+        this.uiManager = null;
         console.log("[MercenaryManager] Initialized");
 
         if (this.eventManager) {
@@ -54,5 +55,21 @@ export class MercenaryManager {
 
     getMercenaries() {
         return this.mercenaries;
+    }
+
+    setUIManager(uiManager) {
+        this.uiManager = uiManager;
+    }
+
+    showMercenaryDetail(mercenary) {
+        if (this.uiManager && this.uiManager.showCharacterSheet) {
+            this.uiManager.showCharacterSheet(mercenary);
+        }
+    }
+
+    hideMercenaryDetail(mercId) {
+        if (this.uiManager && this.uiManager.hideCharacterSheet) {
+            this.uiManager.hideCharacterSheet(mercId);
+        }
     }
 }

--- a/src/managers/squadManager.js
+++ b/src/managers/squadManager.js
@@ -4,11 +4,14 @@ export class SquadManager {
     constructor(eventManager, mercenaryManager) {
         this.eventManager = eventManager;
         this.mercenaryManager = mercenaryManager;
-        this.squads = {
-            squad_1: { name: '1\uBD84\uB300', members: new Set(), strategy: STRATEGY.AGGRESSIVE },
-            squad_2: { name: '2\uBD84\uB300', members: new Set(), strategy: STRATEGY.DEFENSIVE },
-            squad_3: { name: '3\uBD84\uB300', members: new Set(), strategy: STRATEGY.DEFENSIVE }
-        };
+        this.squads = {};
+        for (let i = 1; i <= 9; i++) {
+            this.squads[`squad_${i}`] = {
+                name: `${i}\uBD84\uB300`,
+                members: new Set(),
+                strategy: i === 1 ? STRATEGY.AGGRESSIVE : STRATEGY.DEFENSIVE
+            };
+        }
         this.unassignedMercs = new Set(
             this.mercenaryManager.getMercenaries().map(m => m.id)
         );


### PR DESCRIPTION
## Summary
- delegate opening mercenary detail to `MercenaryManager`
- connect `MercenaryManager` with `UIManager`
- expand `SquadManager` to nine squads for 3x3 grid layout
- drop unused mercenary detail panel markup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685beaeea2708327b5abc900d1bf6065