### PR TITLE
Fix equipment drag & add eager sword

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,6 +102,7 @@
     <div id="squad-management-ui" class="modal-panel ui-frame window draggable-window hidden">
         <button class="close-btn" data-panel-id="squad-management-ui">X</button>
         <h2 class="window-header">부대 편성</h2>
+        <div class="squad-content"></div>
         <div id="formation-grid" class="formation-grid"></div>
     </div>
 

--- a/src/data/items.js
+++ b/src/data/items.js
@@ -168,6 +168,25 @@ export const ITEMS = {
         toughness: 5,
     },
 
+    eager_sword: {
+        name: '열망의 검',
+        type: 'weapon',
+        damageDice: '1d6',
+        tags: ['melee', 'sword'],
+        aspiration: {
+            personality: 'standard',
+            current: 90,
+            max: 100,
+            state: 'inspired',
+        },
+        imageKey: 'sword',
+        stats: { attackPower: 2 },
+        tier: 'rare',
+        durability: 90,
+        weight: 9,
+        toughness: 5,
+    },
+
     estoc: {
         name: '에스톡',
         type: 'weapon',

--- a/src/game.js
+++ b/src/game.js
@@ -218,6 +218,10 @@ export class Game {
         this.equipmentManager.setTagManager(this.tagManager);
 
         this.itemFactory = new ItemFactory(assets);
+        const eagerSword = this.itemFactory.create('eager_sword', 0, 0, this.mapManager.tileSize);
+        if (eagerSword) {
+            this.inventoryManager.getSharedInventory().push(eagerSword);
+        }
         this.pathfindingManager = new PathfindingManager(this.mapManager);
         this.motionManager = new Managers.MotionManager(this.mapManager, this.pathfindingManager);
         this.knockbackEngine = new KnockbackEngine(this.motionManager, this.vfxManager);

--- a/src/managers/inventoryManager.js
+++ b/src/managers/inventoryManager.js
@@ -163,9 +163,7 @@ export class InventoryManager {
     canPlaceItem(item, locationInfo) {
         if (!item) return true;
         if (locationInfo.slot === 'inventory') return true;
-        const itemType = item.type;
-        const itemSlot = item.slot;
-        return itemType === locationInfo.slot || itemSlot === locationInfo.slot;
+        return this.engine.canEquip(item, locationInfo.slot);
     }
 
     getLocation(info) {

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -894,7 +894,9 @@ export class UIManager {
     createSquadManagementUI() {
         const container = this.squadManagementPanel;
         if (!container || !this.mercenaryManager) return;
-        container.innerHTML = '';
+        const content = container.querySelector('.squad-content');
+        if (!content) return;
+        content.innerHTML = '';
 
         const squads = [
             { id: 'unassigned', name: '미편성' },
@@ -947,7 +949,7 @@ export class UIManager {
                 const toSquadId = panel.dataset.squadId || null;
                 this.eventManager?.publish('squad_assign_request', { mercId, toSquadId });
             });
-            container.appendChild(panel);
+            content.appendChild(panel);
             panelMap[sq.id] = panel;
         });
 
@@ -961,7 +963,7 @@ export class UIManager {
                 e.dataTransfer.setData('text/plain', merc.id);
             });
             const squadId = merc.squadId || 'unassigned';
-            const parent = panelMap[squadId] || container;
+            const parent = panelMap[squadId] || content;
             parent.appendChild(el);
         });
 


### PR DESCRIPTION
## Summary
- allow re-equipping items dragged from shared inventory
- preserve header and close button in squad management window
- keep squad panel content while rebuilding
- add special item `열망의 검` that starts inspired
- place the eager sword in the shared inventory at game start

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bed28d568832797177d4e7087ac57