### PR TITLE
Add board-style formation and player auto battle toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@
                 <button id="hire-summoner">소환사 용병 고용 (50골드)</button>
                 <button id="hire-fire-god">불의 신 고용 (100골드)</button>
                 <button id="save-game-btn">게임 저장</button>
+                <button id="toggle-autobattle-btn">자동 전투: OFF</button>
             </div>
         </div>
     </div>

--- a/src/ai.js
+++ b/src/ai.js
@@ -1104,3 +1104,26 @@ export class FireGodAI extends AIArchetype {
         return { type: 'idle' };
     }
 }
+
+// --- Player controlled auto-battle AI ---
+export class PlayerCombatAI extends AIArchetype {
+    constructor() {
+        super();
+        this.currentAI = null;
+    }
+
+    updateBaseAI(entity) {
+        const tags = Array.isArray(entity.equipment.weapon?.tags)
+            ? entity.equipment.weapon.tags
+            : [];
+        const desired = tags.includes('ranged') ? RangedAI : MeleeAI;
+        if (!(this.currentAI instanceof desired)) {
+            this.currentAI = new desired();
+        }
+    }
+
+    decideAction(self, context) {
+        if (!this.currentAI) this.updateBaseAI(self);
+        return this.currentAI.decideAction(self, context);
+    }
+}

--- a/src/entities.js
+++ b/src/entities.js
@@ -1,6 +1,6 @@
 // src/entities.js
 
-import { MeleeAI, RangedAI } from './ai.js';
+import { MeleeAI, RangedAI, PlayerCombatAI } from './ai.js';
 import { StatManager } from './stats.js';
 
 class Entity {
@@ -221,6 +221,7 @@ export class Player extends Entity {
         this.fullness = this.maxFullness;
         this.consumables = [];
         this.consumableCapacity = 4;
+        this.autoBattle = false;
     }
 
     render(ctx) {
@@ -233,6 +234,17 @@ export class Player extends Entity {
         item.quantity = 1;
         this.consumables.push(item);
         return true;
+    }
+
+    updateAI() {
+        if (!this.autoBattle) {
+            this.ai = null;
+            return;
+        }
+        if (!(this.ai instanceof PlayerCombatAI)) {
+            this.ai = new PlayerCombatAI();
+        }
+        this.ai.updateBaseAI(this);
     }
 
 }

--- a/src/game.js
+++ b/src/game.js
@@ -766,6 +766,16 @@ export class Game {
             };
         }
 
+        const autoBtn = document.getElementById('toggle-autobattle-btn');
+        if (autoBtn) {
+            autoBtn.onclick = () => {
+                const player = this.gameState.player;
+                player.autoBattle = !player.autoBattle;
+                if (typeof player.updateAI === 'function') player.updateAI();
+                autoBtn.textContent = `자동 전투: ${player.autoBattle ? 'ON' : 'OFF'}`;
+            };
+        }
+
         // === 메뉴 버튼 이벤트 리스너 수정 ===
         const playerInfoBtn = document.querySelector('.menu-btn[data-panel-id="character-sheet-panel"]');
         if (playerInfoBtn) {

--- a/src/managers/formationManager.js
+++ b/src/managers/formationManager.js
@@ -22,11 +22,18 @@ export class FormationManager {
     }
 
     getSlotPosition(index) {
-        const row = Math.floor(index / this.cols);
-        const col = index % this.cols;
-        let offsetX = (col - Math.floor(this.cols / 2)) * this.tileSize;
-        if (this.orientation === 'RIGHT') offsetX *= -1; // mirror for enemy side
-        const offsetY = (row - Math.floor(this.rows / 2)) * this.tileSize;
+        // Board style mapping so indices map to a 3x3 grid like
+        // 7 4 1 / 8 5 2 / 9 6 3 when orientation is LEFT.
+        // Indices increase along columns rather than rows.
+
+        const r = index % this.rows;
+        const cBase = Math.floor(index / this.rows);
+        const col = this.orientation === 'LEFT'
+            ? this.cols - 1 - cBase
+            : cBase;
+
+        const offsetX = (col - Math.floor(this.cols / 2)) * this.tileSize;
+        const offsetY = (r - Math.floor(this.rows / 2)) * this.tileSize;
         return { x: offsetX, y: offsetY };
     }
 

--- a/src/managers/tagManager.js
+++ b/src/managers/tagManager.js
@@ -1,4 +1,4 @@
-import { RangedAI, MeleeAI } from '../ai.js';
+import { RangedAI, MeleeAI, PlayerCombatAI } from '../ai.js';
 
 export class TagManager {
     constructor() {
@@ -24,6 +24,15 @@ export class TagManager {
     applyWeaponTags(entity) {
         const weapon = entity?.equipment?.weapon;
         if (!weapon) return;
+
+        if (entity.isPlayer) {
+            if (!entity.autoBattle) return;
+            if (!(entity.ai instanceof PlayerCombatAI)) {
+                entity.ai = new PlayerCombatAI();
+            }
+            entity.ai.updateBaseAI(entity);
+            return;
+        }
 
         if (this.hasTag(weapon, 'ranged')) {
             if (!(entity.ai instanceof RangedAI)) {

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -970,19 +970,31 @@ export class UIManager {
         const grid = document.getElementById('formation-grid');
         if (grid && this.formationManager) {
             grid.innerHTML = '';
-            this.formationManager.slots.forEach((id, idx) => {
-                const cell = document.createElement('div');
-                cell.className = 'formation-cell';
-                cell.dataset.index = idx;
-                cell.textContent = id ? id : idx + 1;
-                cell.addEventListener('dragover', e => e.preventDefault());
-                cell.addEventListener('drop', e => {
-                    e.preventDefault();
-                    const entityId = e.dataTransfer.getData('text/plain');
-                    this.eventManager?.publish('formation_assign_request', { entityId, slotIndex: idx });
-                });
-                grid.appendChild(cell);
-            });
+
+            const rows = this.formationManager.rows;
+            const cols = this.formationManager.cols;
+            const orientLeft = this.formationManager.orientation === 'LEFT';
+
+            for (let r = 0; r < rows; r++) {
+                for (let c = 0; c < cols; c++) {
+                    const idx = orientLeft
+                        ? (cols - 1 - c) * rows + r
+                        : c * rows + r;
+                    const id = this.formationManager.slots[idx];
+
+                    const cell = document.createElement('div');
+                    cell.className = 'formation-cell';
+                    cell.dataset.index = idx;
+                    cell.textContent = id ? id : idx + 1;
+                    cell.addEventListener('dragover', e => e.preventDefault());
+                    cell.addEventListener('drop', e => {
+                        e.preventDefault();
+                        const entityId = e.dataTransfer.getData('text/plain');
+                        this.eventManager?.publish('formation_assign_request', { entityId, slotIndex: idx });
+                    });
+                    grid.appendChild(cell);
+                }
+            }
         }
 
         if (!this._squadUIInitialized) {


### PR DESCRIPTION
## Summary
- compute formation slots in board order
- render formation grid using board slot order
- implement `PlayerCombatAI` and player auto-battle support
- skip AI updates for player when auto-battle is off
- allow toggling auto battle in UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bf156fb9483278f7168879b125253