### PR TITLE
Add Twisted status effect and mace skill

### DIFF
--- a/src/data/weapon-skills.js
+++ b/src/data/weapon-skills.js
@@ -67,6 +67,15 @@ export const WEAPON_SKILLS = {
         cooldown: 0,
         tags: ['weapon_skill', 'offensive', 'violin_bow'],
     },
+    // 메이스 레벨 1
+    full_strike: {
+        id: 'full_strike',
+        name: '풀 스트라이크',
+        description: '강력한 일격으로 적을 잠시 뒤틀리게 합니다.',
+        type: 'active',
+        cooldown: 20,
+        tags: ['weapon_skill', 'offensive', 'mace'],
+        twistedDuration: 2000,
+    },
     // 에스톡 레벨 1 (창의 돌진 스킬을 공유)
 };
-

--- a/src/entities.js
+++ b/src/entities.js
@@ -65,6 +65,12 @@ class Entity {
         this.teleportSavedPos = null;
         this.teleportReturnPos = null;
 
+        this.statusEffects = {
+            isTwisted: false,
+            twistedStartTime: 0,
+            twistedDuration: 0,
+        };
+
         // --- 상태이상 및 버프 관련 수치 ---
         this.shield = 0;       // 보호막
         this.damageBonus = 0;  // 추가 공격력
@@ -145,7 +151,9 @@ class Entity {
         ctx.translate(0, yOffset);
         ctx.rotate(rotation);
         ctx.scale(this.direction || 1, 1);
-        if (this.image) {
+        if (this.statusEffects.isTwisted) {
+            this.drawTwistedAnimation(ctx);
+        } else if (this.image) {
             ctx.drawImage(this.image, -this.width / 2, -this.height, this.width, this.height);
         }
 
@@ -166,6 +174,19 @@ class Entity {
         ctx.restore();
     }
 
+    drawTwistedAnimation(ctx) {
+        const elapsed = performance.now() - this.statusEffects.twistedStartTime;
+        const phase = Math.floor(elapsed / 100) % 4;
+        ctx.save();
+        const flip = (phase === 1 || phase === 2) ? -1 : 1;
+        ctx.scale(flip, 1);
+        const scaleX = 0.5;
+        if (this.image) {
+            ctx.drawImage(this.image, (-this.width * scaleX) / 2, -this.height, this.width * scaleX, this.height);
+        }
+        ctx.restore();
+    }
+
     getSaveState() {
         return {
             id: this.id,
@@ -180,6 +201,7 @@ class Entity {
 
     update() {
         this.applyRegen();
+        if (this.statusEffects.isTwisted) return;
         if (this.attackCooldown > 0) this.attackCooldown--;
         for (const skillId in this.skillCooldowns) {
             if (this.skillCooldowns[skillId] > 0) {

--- a/src/game.js
+++ b/src/game.js
@@ -35,7 +35,8 @@ import { rollOnTable } from './utils/random.js';
 import { getMonsterLootTable } from './data/tables.js';
 import { MicroEngine } from './micro/MicroEngine.js';
 import { MicroItemAIManager } from './managers/microItemAIManager.js';
-import { MicroCombatManager } from './micro/MicroCombatManager.js';
+
+import { StatusEffectsManager } from './managers/statusEffectsManager.js';
 import { disarmWorkflow, armorBreakWorkflow } from './workflows.js';
 import { PossessionAIManager } from './managers/possessionAIManager.js';
 import { Ghost } from './entities.js';
@@ -128,7 +129,8 @@ export class Game {
         this.entityManager = new EntityManager(this.eventManager);
         this.inputHandler = new InputHandler(this.eventManager, this);
         this.combatLogManager = new CombatLogManager(this.eventManager);
-        this.systemLogManager = new SystemLogManager(this.eventManager);
+        
+        this.statusEffectsManager = new StatusEffectsManager(this.eventManager);
         this.tagManager = new TagManager();
         this.combatCalculator = new CombatCalculator(this.eventManager, this.tagManager);
         // Player begins in the Aquarium map for feature testing
@@ -1530,6 +1532,7 @@ export class Game {
             playerGroup: this.playerGroup,
             monsterGroup: this.monsterGroup,
             speechBubbleManager: this.speechBubbleManager,
+            statusEffectsManager: this.statusEffectsManager,
             enemies: metaAIManager.groups['dungeon_monsters']?.members || []
         };
         metaAIManager.update(context);

--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -167,6 +167,11 @@ export class MetaAIManager {
                 if (action.skillId === 'parry_stance' && context.effectManager) {
                     context.effectManager.addEffect(entity, 'parry_ready');
                 }
+                if (action.skillId === "full_strike" && action.target) {
+                    eventManager.publish("entity_attack", { attacker: entity, defender: action.target, skill: skillData });
+                    context.statusEffectsManager?.applyTwisted(action.target, skillData.twistedDuration || 2000);
+                    entity.attackCooldown = Math.max(1, Math.round(60 / (entity.attackSpeed || 1)));
+                }
 
                 if (context.speechBubbleManager) {
                     context.speechBubbleManager.addBubble(entity, skillData.name);

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -21,6 +21,7 @@ import { EquipmentRenderManager } from './equipmentRenderManager.js';
 import { ParticleDecoratorManager } from './particleDecoratorManager.js';
 import { TraitManager } from './traitManager.js';
 import { ParasiteManager } from './parasiteManager.js';
+import { StatusEffectsManager } from './statusEffectsManager.js';
 import { MicroItemAIManager } from './microItemAIManager.js';
 import { EffectIconManager } from './effectIconManager.js';
 import { PetManager } from './petManager.js';
@@ -86,5 +87,6 @@ export {
     EntityManager,
     CombatDecisionEngine,
     GuidelineLoader,
+    StatusEffectsManager,
     DataRecorder,
 };

--- a/src/managers/metaAIManager.js
+++ b/src/managers/metaAIManager.js
@@ -88,6 +88,7 @@ export class MetaAIManager extends BaseMetaAI {
 
                 const isCCd = member.effects && member.effects.some(e => e.tags && e.tags.includes('cc'));
                 if (isCCd) continue;
+                if (member.statusEffects && member.statusEffects.isTwisted) continue;
 
                 if (!member.update) {
                     if (member.attackCooldown > 0) member.attackCooldown--;

--- a/src/managers/statusEffectsManager.js
+++ b/src/managers/statusEffectsManager.js
@@ -1,0 +1,37 @@
+export class StatusEffectsManager {
+    constructor(eventManager) {
+        this.eventManager = eventManager;
+    }
+
+    /**
+     * 특정 엔티티에게 '트위스티드' 상태이상을 적용합니다.
+     * @param {Entity} entity - 효과를 적용할 엔티티
+     * @param {number} duration - 지속 시간 (밀리초 단위, e.g., 2000 = 2초)
+     */
+    applyTwisted(entity, duration) {
+        // 이미 다른 행동 불가 상태이상에 걸려있다면 중첩하지 않음 (선택적)
+        if (entity.statusEffects.isStunned || entity.statusEffects.isTwisted) {
+            return;
+        }
+
+        entity.statusEffects.isTwisted = true;
+        entity.statusEffects.twistedStartTime = performance.now();
+        entity.statusEffects.twistedDuration = duration;
+
+        this.eventManager.publish('log', { message: `${entity.name || '유닛'}이(가) 트위스티드 상태에 빠졌습니다!` });
+
+        // 지정된 시간이 지나면 효과 해제
+        setTimeout(() => {
+            this.removeTwisted(entity);
+        }, duration);
+    }
+
+    /**
+     * 엔티티의 트위스티드 효과를 해제합니다.
+     * @param {Entity} entity 
+     */
+    removeTwisted(entity) {
+        entity.statusEffects.isTwisted = false;
+        this.eventManager.publish('log', { message: `${entity.name || '유닛'}이(가) 트위스티드 상태에서 벗어났습니다.` });
+    }
+}

--- a/src/micro/WeaponAI.js
+++ b/src/micro/WeaponAI.js
@@ -176,7 +176,29 @@ export class SaberAI extends EstocAI {}
 
 // --- 신규 무기 AI 클래스 ---
 export class AxeAI extends SwordAI {}
-export class MaceAI extends SwordAI {}
+export class MaceAI extends SwordAI {
+    decideAction(wielder, weapon, context) {
+        const { enemies } = context;
+        if (!enemies || enemies.length === 0) return { type: "idle" };
+        let nearest = null;
+        let minDist = Infinity;
+        for (const e of enemies) {
+            const d = Math.hypot(e.x - wielder.x, e.y - wielder.y);
+            if (d < minDist) { minDist = d; nearest = e; }
+        }
+        if (!nearest) return { type: "idle" };
+        const skillId = "full_strike";
+        if (
+            weapon?.weaponStats?.canUseSkill(skillId) &&
+            (wielder.skillCooldowns[skillId] || 0) <= 0 &&
+            minDist <= wielder.attackRange &&
+            wielder.attackCooldown === 0
+        ) {
+            return { type: "weapon_skill", skillId, target: nearest };
+        }
+        return super.decideAction(wielder, weapon, context);
+    }
+}
 
 export class StaffAI extends BowAI {
     // 지능 수치가 높을수록 기본 공격 피해가 증가합니다.


### PR DESCRIPTION
## Summary
- implement `StatusEffectsManager` for handling twisted debuff
- allow all entities to track and render `twisted` state
- add `full_strike` mace proficiency skill that inflicts twisted
- integrate status effects with meta AI and game context
- update mace AI to use full strike

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bf5389d248327b42f16238d8e3281