### PR TITLE
Update formations and simplify aquarium map

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,6 @@
     <div id="squad-management-ui" class="modal-panel ui-frame window draggable-window hidden">
         <button class="close-btn" data-panel-id="squad-management-ui">X</button>
         <h2 class="window-header">부대 편성</h2>
-        <div class="squad-content"></div>
         <div id="formation-grid" class="formation-grid"></div>
     </div>
 

--- a/src/aquariumMap.js
+++ b/src/aquariumMap.js
@@ -10,8 +10,26 @@ export class AquariumMapManager extends MapManager {
         this.corridorWidth = 5; // widen lane width
         this.jungleWidth = 3;   // slightly thinner jungle corridors
         this.openArea = 6;
-        this.useLanes = SETTINGS.ENABLE_AQUARIUM_LANES;
-        this.map = this._generateMaze();
+        // 테스트 편의를 위해 기본 맵을 넓은 빈 공간으로 생성한다
+        this.useLanes = false;
+        this.map = this._generateEmptyMap();
+    }
+
+    // 벽으로 둘러싸인 빈 맵을 생성한다
+    _generateEmptyMap() {
+        const map = Array.from({ length: this.height }, () =>
+            Array(this.width).fill(this.tileTypes.FLOOR)
+        );
+
+        for (let x = 0; x < this.width; x++) {
+            map[0][x] = this.tileTypes.WALL;
+            map[this.height - 1][x] = this.tileTypes.WALL;
+        }
+        for (let y = 0; y < this.height; y++) {
+            map[y][0] = this.tileTypes.WALL;
+            map[y][this.width - 1] = this.tileTypes.WALL;
+        }
+        return map;
     }
 
     // Generate a simple three-lane layout separated by walls. Left and right edges

--- a/src/managers/formationManager.js
+++ b/src/managers/formationManager.js
@@ -1,8 +1,8 @@
 export class FormationManager {
-    constructor(rows = 3, cols = 3, tileSize = 192, orientation = 'LEFT') {
+    constructor(rows = 5, cols = 5, tileSize = 192, orientation = 'LEFT') {
         // sanitize parameters to avoid invalid array length errors
-        this.rows = Math.max(1, Math.floor(Number(rows) || 3));
-        this.cols = Math.max(1, Math.floor(Number(cols) || 3));
+        this.rows = Math.max(1, Math.floor(Number(rows) || 5));
+        this.cols = Math.max(1, Math.floor(Number(cols) || 5));
         this.tileSize = tileSize;
         this.orientation = orientation; // LEFT or RIGHT
         this.slots = Array(this.rows * this.cols).fill(null); // entity ids
@@ -21,20 +21,21 @@ export class FormationManager {
         this.slots[slotIndex] = entityId;
     }
 
-    getSlotPosition(index) {
-        // Board style mapping so indices map to a 3x3 grid like
-        // 7 4 1 / 8 5 2 / 9 6 3 when orientation is LEFT.
-        // Indices increase along columns rather than rows.
+    getSlotPosition(slotIndex) {
+        if (slotIndex < 0 || slotIndex >= this.slots.length) {
+            return { x: 0, y: 0 };
+        }
+        const row = Math.floor(slotIndex / this.cols);
+        const col = slotIndex % this.cols;
 
-        const r = index % this.rows;
-        const cBase = Math.floor(index / this.rows);
-        const col = this.orientation === 'LEFT'
-            ? this.cols - 1 - cBase
-            : cBase;
+        const centerRow = Math.floor(this.rows / 2);
+        const centerCol = Math.floor(this.cols / 2);
+        const orientationMultiplier = this.orientation === 'RIGHT' ? -1 : 1;
 
-        const offsetX = (col - Math.floor(this.cols / 2)) * this.tileSize;
-        const offsetY = (r - Math.floor(this.rows / 2)) * this.tileSize;
-        return { x: offsetX, y: offsetY };
+        const relativeX = (col - centerCol) * this.tileSize * orientationMultiplier;
+        const relativeY = (row - centerRow) * this.tileSize;
+
+        return { x: relativeX, y: relativeY };
     }
 
     apply(origin, entityMap) {

--- a/style.css
+++ b/style.css
@@ -526,20 +526,27 @@ body, html {
     font-size: 12px;
 }
 
+
 .formation-grid {
     display: grid;
-    grid-template-columns: repeat(3, 40px);
-    grid-template-rows: repeat(3, 40px);
-    gap: 4px;
-    margin-top: 8px;
+    /* 5x5 grid with larger cells */
+    grid-template-columns: repeat(5, 80px);
+    grid-template-rows: repeat(5, 80px);
+    gap: 8px;
+    margin-top: 15px;
+    padding: 10px;
+    background-color: rgba(0,0,0,0.2);
+    border-radius: 5px;
 }
 
 .formation-cell {
-    border: 1px solid #555;
-    width: 40px;
-    height: 40px;
+    border: 1px solid #777;
+    width: 80px;
+    height: 80px;
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: rgba(0,0,0,0.3);
+    background-color: rgba(0,0,0,0.4);
+    font-size: 14px;
+    color: #ccc;
 }


### PR DESCRIPTION
## Summary
- make Aquarium map an empty arena for easier testing
- enlarge formation grid UI and remove unused list panel
- support 5x5 formations facing left or right
- place troops using FormationManager with wide spacing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bfbf99f288327b4e512a682abdbeb