### PR TITLE
Fix formation manager init

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -180,6 +180,8 @@ export class Game {
                 name !== 'SkillManager' &&
                 name !== 'ProjectileManager' &&
                 name !== 'SquadManager' &&
+                name !== 'FormationManager' &&
+                name !== 'EnemyFormationManager' &&
                 name !== 'DataRecorder'
         );
         for (const managerName of otherManagerNames) {


### PR DESCRIPTION
## Summary
- skip instantiating `FormationManager` and `EnemyFormationManager` in the generic manager loader
- avoids RangeError caused by passing wrong arguments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c2a53665c832780c69de9d2fbda20