### PR TITLE
Fix missing FormationManager.assign and orientation support

### DIFF
--- a/src/managers/enemyFormationManager.js
+++ b/src/managers/enemyFormationManager.js
@@ -11,7 +11,7 @@ import { MeleeAI, RangedAI, HealerAI } from '../ai.js';
  */
 export class EnemyFormationManager extends FormationManager {
     constructor(rows = 3, cols = 3, tileSize = 192) {
-        super(rows, cols, tileSize, 'RIGHT');
+        super(rows, cols, tileSize, null, 'RIGHT');
         this.rules = [];
         this._registerDefaultRules();
     }

--- a/src/managers/formationManager.js
+++ b/src/managers/formationManager.js
@@ -1,8 +1,9 @@
 class FormationManager {
-    constructor(cols, rows, tileSize, eventManager = null) {
+    constructor(cols, rows, tileSize, eventManager = null, orientation = 'RIGHT') {
         this.cols = cols;
         this.rows = rows;
         this.tileSize = tileSize; // 타일 크기 (예: 64)
+        this.orientation = orientation;
         this.slots = new Array(cols * rows).fill(null); // 각 슬롯에는 분대(squad) 객체가 저장됨
         this.eventManager = eventManager;
         this.eventManager?.subscribe('formation_assign_request', this.handleAssignSquad.bind(this));
@@ -24,9 +25,51 @@ class FormationManager {
         this.eventManager?.publish('formation_data_changed', { slots: this.slots });
     }
 
+    /**
+     * 직접 슬롯에 엔티티(또는 ID)를 배치합니다.
+     * 테스트나 게임 로직에서 편리하게 사용하기 위한 메서드입니다.
+     */
+    assign(slotIndex, entityId) {
+        if (slotIndex < 0 || slotIndex >= this.slots.length) return;
+        this.slots[slotIndex] = entityId;
+        this.eventManager?.publish('formation_data_changed', { slots: this.slots });
+    }
+
+    /**
+     * 행 또는 열 크기를 조정합니다.
+     * 기존 슬롯 데이터는 가능한 한 보존합니다.
+     */
+    resize(newRows, newCols) {
+        const newSlots = new Array(newRows * newCols).fill(null);
+        for (let r = 0; r < Math.min(this.rows, newRows); r++) {
+            for (let c = 0; c < Math.min(this.cols, newCols); c++) {
+                const oldIdx = this._indexFromCoords(c, r);
+                const newIdx = this.orientation === 'LEFT'
+                    ? (newCols - 1 - c) * newRows + r
+                    : c * newRows + r;
+                newSlots[newIdx] = this.slots[oldIdx];
+            }
+        }
+        this.rows = newRows;
+        this.cols = newCols;
+        this.slots = newSlots;
+    }
+
+    _indexFromCoords(col, row) {
+        if (this.orientation === 'LEFT') {
+            return (this.cols - 1 - col) * this.rows + row;
+        }
+        return col * this.rows + row;
+    }
+
     getSlotPosition(index) {
-        const x = (index % this.cols) * this.tileSize;
-        const y = Math.floor(index / this.cols) * this.tileSize;
+        const row = index % this.rows;
+        let col = Math.floor(index / this.rows);
+        if (this.orientation === 'LEFT') {
+            col = this.cols - 1 - col;
+        }
+        const x = col * this.tileSize;
+        const y = row * this.tileSize;
         return { x, y };
     }
 


### PR DESCRIPTION
## Summary
- add orientation handling and resize logic to `FormationManager`
- implement a simple `assign` method for direct slot usage
- update `EnemyFormationManager` to pass orientation properly
- confirm tests pass

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c2c7965748327bb68ced5d85073e6