### PR TITLE
Refactor turn management for simpler AI flow

### DIFF
--- a/src/managers/worldAIManager.js
+++ b/src/managers/worldAIManager.js
@@ -5,6 +5,7 @@ export class WorldAIManager {
         this.movementEngine = movementEngine;
         this.combatManager = combatManager;
         this.apManager = apManager;
+        this.isProcessing = false; // 현재 AI가 행동 중인지 여부를 나타내는 플래그
     }
 
     /**
@@ -14,31 +15,40 @@ export class WorldAIManager {
      * @param {function} onTurnEnd - 턴 종료 시 호출될 콜백 함수
      */
     handleMonsterTurn(monster, player, onTurnEnd) {
-        const performAction = () => {
-            // 움직이는 중이거나 AP가 없으면 행동을 멈추고 턴을 종료합니다.
-            if (this.movementEngine.isMoving(monster) || !this.apManager.hasEnoughAP(monster, 1)) {
-                onTurnEnd();
-                return;
-            }
+        // 이미 다른 AI 루틴이 실행 중이라면 중복 실행을 방지합니다.
+        if (this.isProcessing) return;
 
-            // 1. 플레이어가 사거리 내에 있으면 공격
+        this.isProcessing = true;
+
+        const performAction = () => {
+            // 1. 공격이 가능하면 즉시 공격하고 턴을 종료합니다.
             if (this.combatManager.isAdjacent(monster, player)) {
                 this.combatManager.attemptAttack(monster, player);
-                onTurnEnd(); // 공격 후에는 바로 턴 종료
+                this.isProcessing = false;
+                onTurnEnd(); // 턴 종료 콜백 호출
                 return;
             }
 
-            // 2. 사거리 밖에 있으면 이동
-            const nextStep = this.walkManager.getNextStep(monster, player);
-            if (nextStep && this.apManager.spendAP(monster, 1)) {
-                this.movementEngine.startMovement(monster, nextStep);
-                // 이동 후 다음 행동을 결정하기 위해 잠시 후 다시 이 함수를 호출합니다.
-                setTimeout(performAction, 300); // 0.3초 후 다음 행동 결정
-            } else {
-                onTurnEnd(); // 더 이상 이동할 수 없으면 턴 종료
+            // 2. 이동할 AP가 남아있으면 플레이어를 향해 이동합니다.
+            if (this.apManager.hasEnoughAP(monster, 1)) {
+                const nextStep = this.walkManager.getNextStep(monster, player);
+                if (nextStep) {
+                    this.apManager.spendAP(monster, 1);
+                    this.movementEngine.startMovement(monster, nextStep);
+                    // 이동이 끝난 후 다시 행동을 결정해야 하므로, 여기서는 턴을 종료하지 않습니다.
+                    // worldEngine의 update 루프가 이동이 끝난 것을 감지하고 다시 AI를 깨울 것입니다.
+                    this.isProcessing = false;
+                    return;
+                }
             }
+
+            // 3. 더 이상 할 수 있는 행동이 없으면 턴을 종료합니다.
+            // (AP가 없거나, 이동할 경로가 없는 경우)
+            this.isProcessing = false;
+            onTurnEnd();
         };
 
+        // 몬스터의 행동을 시작합니다.
         performAction();
     }
 }

--- a/src/managers/worldTurnManager.js
+++ b/src/managers/worldTurnManager.js
@@ -3,10 +3,10 @@ export class WorldTurnManager {
     constructor() {
         this.entities = [];
         this.turnIndex = -1;
-        this.turnProcessed = false; // 현재 턴의 로직이 처리되었는지 여부
     }
     
     setEntities(entities) {
+        // null이나 undefined 같은 비정상적인 값이 배열에 포함되지 않도록 필터링합니다.
         this.entities = entities.filter(e => e);
         this.turnIndex = -1;
     }
@@ -16,31 +16,24 @@ export class WorldTurnManager {
     }
 
     nextTurn() {
-        if (this.entities.length === 0) return;
+        if (this.entities.length === 0) {
+            this.turnIndex = -1;
+            return;
+        }
         this.turnIndex = (this.turnIndex + 1) % this.entities.length;
-        this.turnProcessed = false; // 새 턴이 시작되면 플래그 초기화
     }
 
     getCurrentTurnEntity() {
+        if (this.turnIndex === -1 || this.entities.length === 0) {
+            return null;
+        }
         return this.entities[this.turnIndex];
     }
     
-    getCurrentTurnOwner() {
-        const entity = this.getCurrentTurnEntity();
-        if (!entity) return 'NONE';
-        // 플레이어 객체는 'entity' 속성을 통해 구분합니다.
-        return entity.entity ? 'PLAYER' : 'ENEMY';
-    }
-
     isPlayerTurn() {
-        return this.getCurrentTurnOwner() === 'PLAYER';
-    }
-
-    isTurnProcessed() {
-        return this.turnProcessed;
-    }
-
-    markTurnAsProcessed() {
-        this.turnProcessed = true;
+        const entity = this.getCurrentTurnEntity();
+        if (!entity) return false;
+        // 플레이어 객체는 'entity'라는 고유 속성을 가지고 있다는 점을 이용합니다.
+        return !!entity.entity;
     }
 }


### PR DESCRIPTION
## Summary
- simplify `WorldTurnManager` by removing processed flags
- trigger enemy AI immediately when a new turn starts and refresh AP once
- delegate enemy actions through a guarded `WorldAIManager`
- update `worldEngine` logic to rely on the new flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686317579c4c832784e28baa85ee44b8