### PR TITLE
Fix arrow key clearing in world engine

### DIFF
--- a/src/inputHandler.js
+++ b/src/inputHandler.js
@@ -59,4 +59,15 @@ export class InputHandler {
             this.game.eventManager?.publish('mouse_wheel', { direction });
         }
     }
+
+    clearKey(key) {
+        delete this.keysPressed[key];
+    }
+
+    clearArrowKeys() {
+        this.clearKey('ArrowUp');
+        this.clearKey('ArrowDown');
+        this.clearKey('ArrowLeft');
+        this.clearKey('ArrowRight');
+    }
 }


### PR DESCRIPTION
## Summary
- provide missing `clearKey` and `clearArrowKeys` functions in input handler

## Testing
- `node run-tests.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68631b0099b883278e8ac449d930eb88