### PR TITLE
Implement isActionInProgress for world turns

### DIFF
--- a/src/managers/worldTurnManager.js
+++ b/src/managers/worldTurnManager.js
@@ -1,7 +1,8 @@
 // src/managers/worldTurnManager.js
 export class WorldTurnManager {
-    constructor() {
-        this.entities = [];
+    constructor({ movementEngine = null, entities = [] } = {}) {
+        this.movementEngine = movementEngine;
+        this.entities = entities.filter(e => e);
         this.turnIndex = -1;
         this.turnProcessed = false; // 현재 턴의 로직이 처리되었는지 여부
     }
@@ -42,5 +43,15 @@ export class WorldTurnManager {
 
     markTurnAsProcessed() {
         this.turnProcessed = true;
+    }
+
+    /**
+     * 현재 어떤 엔티티든 이동 중인지 확인합니다.
+     * MovementEngine이 제공될 때만 동작합니다.
+     * @returns {boolean} 이동 중 여부
+     */
+    isActionInProgress() {
+        if (!this.movementEngine) return false;
+        return this.entities.some(entity => this.movementEngine.isMoving(entity));
     }
 }

--- a/src/worldEngine.js
+++ b/src/worldEngine.js
@@ -67,7 +67,7 @@ export class WorldEngine {
             this.player.movementEngine = this.movementEngine;
         }
         if (this.turnManager) {
-            this.turnManager.entities = [this.player, ...this.monsters];
+            this.turnManager.setEntities([this.player, ...this.monsters]);
         }
     }
 


### PR DESCRIPTION
## Summary
- add `movementEngine` support to `WorldTurnManager`
- implement `isActionInProgress` to detect ongoing movements
- update `WorldEngine` to use `setEntities` when setting player

## Testing
- `npm test` *(fails: TensorFlow libraries not initialized, tests log errors but some pass)*

------
https://chatgpt.com/codex/tasks/task_e_686358bd5b788327b41e6351881f4a8a